### PR TITLE
feat: implementação completa das 9 fases de evolução

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,8 @@ import Qualifiers from './screens/Qualifiers';
 import Finals from './screens/Final';
 import FinalResults from './screens/FinalResults';
 import RoundsOverview from './screens/RoundsOverview';
+import CompetitorHistory from './screens/CompetitorHistory';
+import Announcer from './screens/Announcer';
 
 export default function App() {
   return (
@@ -43,6 +45,8 @@ export default function App() {
                     <Route path="final" element={<Finals />} />
                     <Route path="final-results" element={<FinalResults />} />
                     <Route path="overview" element={<RoundsOverview />} />
+                    <Route path="competitor/:competitorId/history" element={<CompetitorHistory />} />
+                    <Route path="announcer" element={<Announcer />} />
                     <Route index element={<Navigate to="registration" replace />} />
                   </Route>
                 </Route>

--- a/src/components/layout/CompetitionLayout.tsx
+++ b/src/components/layout/CompetitionLayout.tsx
@@ -13,6 +13,7 @@ const steps = [
   { key: 'record', label: 'Qualificatória', icon: '🐄' },
   { key: 'final', label: 'Final', icon: '🏆' },
   { key: 'final-results', label: 'Resultados', icon: '📊' },
+  { key: 'announcer', label: 'Locutor', icon: '🎙️' },
 ];
 
 export function CompetitionLayout() {
@@ -90,7 +91,7 @@ export function CompetitionLayout() {
       </header>
 
       {/* Step Navigation */}
-      <nav className="bg-white border-b border-dust-300 px-4 overflow-x-auto">
+      <nav className="bg-white border-b border-dust-300 px-2 sm:px-4 overflow-x-auto">
         <div className="flex gap-0 max-w-5xl mx-auto">
           {steps.map((step) => (
             <NavLink
@@ -98,7 +99,7 @@ export function CompetitionLayout() {
               to={`/competition/${id}/${step.key}`}
               className={({ isActive }) =>
                 [
-                  'flex items-center gap-1.5 px-4 py-3 text-sm font-medium whitespace-nowrap',
+                  'flex items-center gap-1 sm:gap-1.5 px-2.5 sm:px-4 py-3 text-xs sm:text-sm font-medium whitespace-nowrap',
                   'border-b-2 transition-colors',
                   isActive
                     ? 'border-saddle-600 text-saddle-700'
@@ -107,7 +108,7 @@ export function CompetitionLayout() {
               }
             >
               <span>{step.icon}</span>
-              <span>{step.label}</span>
+              <span className="hidden sm:inline">{step.label}</span>
             </NavLink>
           ))}
         </div>

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -11,19 +11,19 @@ interface CategoryBadgeProps {
 
 const categoryConfig: Record<RiderCategory, { label: string; className: string }> = {
   Open: {
-    label: 'Aberta',
+    label: 'Profissional',
     className: 'bg-hay-200 text-rope-700 border border-hay-400',
   },
   Amateur19: {
-    label: 'Amador',
+    label: 'Amador Avançado',
     className: 'bg-pasture-100 text-pasture-800 border border-pasture-400',
   },
   AmateurLight: {
-    label: 'Amador Light',
+    label: 'Amador',
     className: 'bg-saddle-100 text-saddle-700 border border-saddle-400',
   },
   Beginner: {
-    label: 'Principiante',
+    label: 'Iniciante',
     className: 'bg-dust-200 text-rope-500 border border-dust-400',
   },
 };

--- a/src/components/ui/PageHeader.tsx
+++ b/src/components/ui/PageHeader.tsx
@@ -12,8 +12,8 @@ interface PageHeaderProps {
 export function PageHeader({ title, subtitle, backTo, backLabel = 'Voltar', actions }: PageHeaderProps) {
   const navigate = useNavigate();
   return (
-    <div className="flex items-start justify-between mb-6">
-      <div>
+    <div className="flex flex-wrap items-start justify-between gap-3 mb-6">
+      <div className="min-w-0">
         {backTo && (
           <button
             onClick={() => navigate(backTo)}
@@ -25,14 +25,14 @@ export function PageHeader({ title, subtitle, backTo, backLabel = 'Voltar', acti
             {backLabel}
           </button>
         )}
-        <h1 className="font-serif font-bold text-rope-800 text-2xl md:text-3xl leading-tight">
+        <h1 className="font-serif font-bold text-rope-800 text-xl md:text-3xl leading-tight">
           {title}
         </h1>
         {subtitle && (
           <p className="text-rope-400 text-sm mt-1">{subtitle}</p>
         )}
       </div>
-      {actions && <div className="flex items-center gap-2 mt-1">{actions}</div>}
+      {actions && <div className="flex flex-wrap items-center gap-2 mt-1 shrink-0">{actions}</div>}
     </div>
   );
 }

--- a/src/components/ui/QuickSelect.tsx
+++ b/src/components/ui/QuickSelect.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+interface QuickSelectProps {
+  label: string;
+  value: number | null;
+  onChange: (v: number) => void;
+  min: number;
+  max: number;
+  cols?: number;
+}
+
+export function QuickSelect({ label, value, onChange, min, max, cols = 6 }: QuickSelectProps) {
+  const nums = Array.from({ length: max - min + 1 }, (_, i) => min + i);
+  return (
+    <div>
+      <p className="text-sm font-medium text-rope-700 mb-2">{label}</p>
+      <div
+        className="grid gap-1.5"
+        style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}
+      >
+        {nums.map((n) => (
+          <button
+            key={n}
+            type="button"
+            onClick={() => onChange(n)}
+            className={[
+              'py-2 rounded-lg text-sm font-semibold border transition-all min-h-[40px]',
+              value === n
+                ? 'bg-saddle-600 text-white border-saddle-700 shadow-sm'
+                : 'bg-white text-rope-700 border-dust-300 hover:border-saddle-400 hover:bg-dust-50',
+            ].join(' ')}
+          >
+            {n}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/context/ResultContext.tsx
+++ b/src/context/ResultContext.tsx
@@ -32,14 +32,16 @@ interface ResultsContextValue {
     duoId: string,
     cattleCount: number,
     timeSeconds: number,
-    isSAT?: boolean
+    isSAT?: boolean,
+    calledCattle?: number
   ) => void;
 
   /** Atualiza resultado existente da qualificatória */
   updateQualifierResult: (
     duoId: string,
     cattleCount: number,
-    timeSeconds: number
+    timeSeconds: number,
+    calledCattle?: number
   ) => void;
 
   /** Adiciona resultado da final */
@@ -47,7 +49,8 @@ interface ResultsContextValue {
     duoId: string,
     cattleCount: number,
     timeSeconds: number,
-    isSAT?: boolean
+    isSAT?: boolean,
+    calledCattle?: number
   ) => void;
 
   /** Mapa com o melhor resultado por dupla nas qualificatórias */
@@ -89,7 +92,8 @@ export function ResultsProvider({ children }: { children: React.ReactNode }) {
     duoId: string,
     cattleCount: number,
     timeSeconds: number,
-    isSAT = false
+    isSAT = false,
+    calledCattle?: number
   ) {
     const newResult: PassResult = {
       id: crypto.randomUUID(),
@@ -98,16 +102,17 @@ export function ResultsProvider({ children }: { children: React.ReactNode }) {
       cattleCount: isSAT ? 0 : cattleCount,
       timeSeconds: isSAT ? 120 : timeSeconds,
       isSAT,
+      calledCattle,
       createdAtISO: new Date().toISOString(),
     };
     setResults((prev) => [...prev, newResult]);
   }
 
-  /** Atualiza resultado existente da qualificatória */
   function updateQualifierResult(
     duoId: string,
     cattleCount: number,
-    timeSeconds: number
+    timeSeconds: number,
+    calledCattle?: number
   ) {
     setResults((prev) =>
       prev.map((r) =>
@@ -116,6 +121,7 @@ export function ResultsProvider({ children }: { children: React.ReactNode }) {
               ...r,
               cattleCount,
               timeSeconds,
+              calledCattle,
               updatedAtISO: new Date().toISOString(),
             }
           : r
@@ -127,7 +133,8 @@ export function ResultsProvider({ children }: { children: React.ReactNode }) {
     duoId: string,
     cattleCount: number,
     timeSeconds: number,
-    isSAT = false
+    isSAT = false,
+    calledCattle?: number
   ) {
     const newResult: PassResult = {
       id: crypto.randomUUID(),
@@ -136,6 +143,7 @@ export function ResultsProvider({ children }: { children: React.ReactNode }) {
       cattleCount: isSAT ? 0 : cattleCount,
       timeSeconds: isSAT ? 120 : timeSeconds,
       isSAT,
+      calledCattle,
       createdAtISO: new Date().toISOString(),
     };
     setFinalResults((prev) => [...prev, newResult]);

--- a/src/core/logic/pairing.ts
+++ b/src/core/logic/pairing.ts
@@ -70,7 +70,7 @@ function roundRobinPairs(
   for (const pairs of rounds) {
     for (const [a, b] of pairs) {
       if (!canPair(a.category, b.category)) continue;
-      const id = [a.id, b.id].sort().join('🤝');
+      const id = [a.id, b.id].sort().join('_');
       duos.push({
         id,
         riderOneId: a.id,
@@ -159,7 +159,7 @@ function havelHakimiRegular(
       const a = byId.get(aId)!;
       const b = byId.get(bId)!;
       return {
-        id: [aId, bId].join('🤝'),
+        id: [aId, bId].join('_'),
         riderOneId: aId,
         riderTwoId: bId,
         group: computeDuoGroup(a.category, b.category),

--- a/src/core/logic/pairing.ts
+++ b/src/core/logic/pairing.ts
@@ -8,7 +8,7 @@ export interface PairingOutput {
 
 export interface PairingOptions {
   rngSeed?: number;
-  passesPerCompetitor?: number; // 👈 usa SEMPRE o valor global passado pela tela
+  passesPerCompetitor?: number;
   method?: 'auto' | 'roundRobin' | 'havelHakimi';
 }
 
@@ -28,7 +28,6 @@ function shuffleInPlace<T>(arr: T[], seedState: { seed: number }) {
 /**
  * Round-robin (método do círculo) — funciona para N par.
  * Gera N-1 rodadas; cada rodada tem N/2 duplas, cobrindo todas as combinações sem repetição.
- * Se "passes" < N-1, devolvemos apenas as primeiras "passes" rodadas.
  */
 function roundRobinPairs(
   competitors: Competitor[],
@@ -39,33 +38,26 @@ function roundRobinPairs(
   if (n % 2 !== 0)
     throw new Error('Round-robin requer número PAR de competidores.');
 
-  // embaralha ordem inicial para variar o sorteio
   const order = [...competitors];
   shuffleInPlace(order, seedState);
 
   const rounds: Array<Array<[Competitor, Competitor]>> = [];
-  // método do círculo: fixa o primeiro e rotaciona o resto
   const fixed = order[0];
-  let ring = order.slice(1); // tamanho n-1
+  let ring = order.slice(1);
 
   const totalPossibleRounds = n - 1;
   const useRounds = Math.min(passes, totalPossibleRounds);
 
   for (let r = 0; r < useRounds; r++) {
     const pairs: Array<[Competitor, Competitor]> = [];
-    // par 0: fixed com último do ring
     pairs.push([fixed, ring[ring.length - 1]]);
-    // pares restantes: i vs (len-2-i)
     for (let i = 0; i < n / 2 - 1; i++) {
       pairs.push([ring[i], ring[ring.length - 2 - i]]);
     }
     rounds.push(pairs);
-
-    // rotação: move o último para o começo
     ring = [ring[ring.length - 1], ...ring.slice(0, ring.length - 1)];
   }
 
-  // flatten e map para Duo (filtra pares inválidos por ASQM)
   const duos: Duo[] = [];
   for (const pairs of rounds) {
     for (const [a, b] of pairs) {
@@ -83,7 +75,7 @@ function roundRobinPairs(
 }
 
 /**
- * Havel–Hakimi para sequência regular (todos com o mesmo grau = passes).
+ * Havel–Hakimi para sequência regular ou heterogênea (graus diferentes por competidor).
  * Funciona para N ímpar (quando N*passes é par) ou como fallback geral.
  * Recomeça com outra seed se encalhar (até maxTries).
  */
@@ -91,31 +83,27 @@ function havelHakimiRegular(
   competitors: Competitor[],
   passes: number,
   seedState: { seed: number },
-  maxTries = 50
+  maxTries = 50,
+  extraCompetitorId?: string
 ): Duo[] {
-  const n = competitors.length;
-  const neededEdges = (n * passes) / 2;
-
   for (let attempt = 0; attempt < maxTries; attempt++) {
-    // estado
     const nodes = competitors.map((c) => ({
       id: c.id,
       category: c.category,
-      remaining: passes,
+      // Competidor com passada extra recebe 1 a mais
+      remaining: c.id === extraCompetitorId ? passes + 1 : passes,
       neighbors: new Set<string>(),
     }));
 
-    // quebra empates com shuffle leve
     shuffleInPlace(nodes, seedState);
 
     const byId = new Map(nodes.map((x) => [x.id, x]));
     const edges: Array<[string, string]> = [];
 
     let ok = true;
-    // enquanto houver algum com remaining > 0
     while (true) {
       nodes.sort((a, b) => b.remaining - a.remaining);
-      if (nodes[0].remaining === 0) break; // terminou
+      if (nodes[0].remaining === 0) break;
 
       const v = nodes[0];
       const r = v.remaining;
@@ -130,11 +118,10 @@ function havelHakimiRegular(
         );
 
       if (candidates.length < r) {
-        ok = false; // encalhou
+        ok = false;
         break;
       }
 
-      // conecta v aos r primeiros (maiores remaining), com leve randomização
       shuffleInPlace(candidates, seedState);
       candidates.sort((a, b) => b.remaining - a.remaining);
       const chosen = candidates.slice(0, r);
@@ -149,12 +136,8 @@ function havelHakimiRegular(
       }
     }
 
-    if (!ok) {
-      // tenta de novo com outra seed
-      continue;
-    }
+    if (!ok) continue;
 
-    // converte arestas em Duos
     const duos: Duo[] = edges.map(([aId, bId]) => {
       const a = byId.get(aId)!;
       const b = byId.get(bId)!;
@@ -166,8 +149,11 @@ function havelHakimiRegular(
       };
     });
 
-    if (duos.length === neededEdges) {
-      // embaralha a ordem final para não ficar previsível
+    const totalEdges = extraCompetitorId
+      ? ((competitors.length - 1) * passes + (passes + 1)) / 2
+      : (competitors.length * passes) / 2;
+
+    if (duos.length === totalEdges) {
       shuffleInPlace(duos, seedState);
       return duos;
     }
@@ -187,14 +173,11 @@ export function generateUniqueDuos(
   const n = competitorsInput.length;
   if (n < 2) throw new Error('É necessário pelo menos 2 competidores.');
 
-  // 👇 usa o passes global se passado; se não, tenta inferir
   let passes = options.passesPerCompetitor;
   if (passes == null) {
     const distinct = new Set(competitorsInput.map((c) => c.passes));
     if (distinct.size !== 1) {
-      throw new Error(
-        'Número de passadas deve ser único para todos os competidores.'
-      );
+      throw new Error('Número de passadas deve ser único para todos os competidores.');
     }
     passes = competitorsInput[0].passes;
   }
@@ -209,44 +192,57 @@ export function generateUniqueDuos(
     );
   }
 
-  // condição necessária: N * passes precisa ser par
-  if ((n * passes) % 2 !== 0) {
-    throw new Error(`N x passadas deve ser par. N=${n}, passadas=${passes}.`);
-  }
-
   const competitors: Competitor[] = competitorsInput.map((c) => ({
     ...c,
-    passes: passes!, // garante que seja number
+    passes: passes!,
   }));
+
+  const warnings: string[] = [];
+  let extraCompetitorId: string | undefined;
+
+  // Quando N*passes é ímpar (N ímpar e passes ímpar), sortear um competidor para receber passada extra
+  if ((n * passes) % 2 !== 0) {
+    const idx = Math.floor(seededRandom(seedState) * n);
+    extraCompetitorId = competitors[idx].id;
+    warnings.push(
+      `${competitors[idx].name} recebeu uma passada extra por número ímpar de competidores.`
+    );
+  }
 
   let duos: Duo[] = [];
   if (
     (options.method === 'roundRobin' || options.method === 'auto') &&
-    n % 2 === 0
+    n % 2 === 0 &&
+    !extraCompetitorId
   ) {
     duos = roundRobinPairs(competitors, passes, seedState);
   } else if (options.method === 'roundRobin' && n % 2 !== 0) {
     throw new Error('Round-robin requer número PAR de competidores.');
   } else {
-    duos = havelHakimiRegular(competitors, passes, seedState);
+    duos = havelHakimiRegular(competitors, passes, seedState, 50, extraCompetitorId);
   }
 
-  // Detect competitors who received fewer rounds than requested due to category
-  // incompatibilities silently dropping pairs (round-robin skips invalid combos).
+  // Atribui passNumber sequencial a cada dupla
+  duos = duos.map((d, i) => ({ ...d, passNumber: i + 1 }));
+
+  // Detecta competidores que ficaram com menos passadas por incompatibilidade de categoria
   const roundCount = new Map<string, number>();
   for (const duo of duos) {
     roundCount.set(duo.riderOneId, (roundCount.get(duo.riderOneId) ?? 0) + 1);
     roundCount.set(duo.riderTwoId, (roundCount.get(duo.riderTwoId) ?? 0) + 1);
   }
   const underserved = competitors.filter(
-    (c) => (roundCount.get(c.id) ?? 0) < passes!
+    (c) => {
+      const expected = c.id === extraCompetitorId ? passes! + 1 : passes!;
+      return (roundCount.get(c.id) ?? 0) < expected;
+    }
   );
-  const warnings: string[] = underserved.length > 0
-    ? [
-        `${underserved.length} competidor(es) ficaram com menos passadas por falta de adversários compatíveis: ` +
-        underserved.map((c) => c.name).join(', '),
-      ]
-    : [];
+  if (underserved.length > 0) {
+    warnings.push(
+      `${underserved.length} competidor(es) ficaram com menos passadas por falta de adversários compatíveis: ` +
+      underserved.map((c) => c.name).join(', ')
+    );
+  }
 
   return { duos, warnings };
 }

--- a/src/core/models/Duo.ts
+++ b/src/core/models/Duo.ts
@@ -8,10 +8,11 @@ export interface Duo {
   riderTwoId: string;
   group: DuoGroup;
   label?: string;
+  passNumber?: number;
 }
 
 export function duoKeyFromRiders(riderAId: string, riderBId: string): string {
-  return [riderAId, riderBId].sort().join('🤝');
+  return [riderAId, riderBId].sort().join('_');
 }
 
 /**

--- a/src/core/models/PassResult.ts
+++ b/src/core/models/PassResult.ts
@@ -22,6 +22,9 @@ export interface PassResult {
   /** Indica se foi Sem Aproveitamento Técnico (SAT) */
   isSAT?: boolean;
 
+  /** Número do boi cantado (0–9), campo informativo */
+  calledCattle?: number;
+
   /** Data/hora da criação (ISO) */
   createdAtISO?: string;
 }

--- a/src/screens/Announcer/index.tsx
+++ b/src/screens/Announcer/index.tsx
@@ -1,0 +1,170 @@
+import React, { useMemo } from 'react';
+import { useResults } from 'context/ResultContext';
+import { useCompetition } from '../../context/CompetitionContext';
+import { PassResult } from 'core/models/PassResult';
+import { GroupBadge } from '../../components/ui/Badge';
+import { Button } from '../../components/ui/Button';
+
+function StatCard({ label, value, highlight }: { label: string; value: string | number; highlight?: boolean }) {
+  return (
+    <div className={`rounded-xl p-4 border ${highlight ? 'bg-saddle-800 border-saddle-700 text-white' : 'bg-white border-dust-300'}`}>
+      <p className={`text-xs uppercase tracking-wide mb-1 ${highlight ? 'text-saddle-300' : 'text-rope-400'}`}>{label}</p>
+      <p className={`text-3xl font-bold font-serif ${highlight ? 'text-white' : 'text-rope-800'}`}>{value}</p>
+    </div>
+  );
+}
+
+function requestFullscreen() {
+  try {
+    if (document.documentElement.requestFullscreen) {
+      document.documentElement.requestFullscreen();
+    }
+  } catch {
+    // Ignore unsupported browsers
+  }
+}
+
+export default function Announcer() {
+  const { results, finalResults, duosMeta, getFinalists } = useResults();
+  const { competition, duos: compDuos } = useCompetition();
+
+  const status = competition?.status ?? 'qualifier';
+  const allDuos = duosMeta.length > 0 ? duosMeta : compDuos;
+
+  // Determina quais resultados e duplas usar conforme etapa
+  const activeResults = status === 'final' ? finalResults : results;
+  const stage = status === 'final' ? 'Final' : 'Qualifier';
+
+  const registeredIds = useMemo(
+    () => new Set(activeResults.filter((r: PassResult) => r.stage === stage).map((r) => r.duoId)),
+    [activeResults, stage]
+  );
+
+  // Para a final, precisamos da lista ordenada de finalistas
+  const finalists = useMemo(() => {
+    if (status !== 'final') return null;
+    return getFinalists();
+  }, [status, results]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const orderedDuos = useMemo(() => {
+    if (status === 'final' && finalists) {
+      // Exibe 2D primeiro, depois 1D — reverso (pior entra primeiro)
+      const all2D = [...finalists.finalists2D].reverse();
+      const all1D = [...finalists.finalists1D].reverse();
+      const combined = [...all2D, ...all1D];
+      return combined
+        .map((entry) => allDuos.find((d) => d.id === entry.duoId))
+        .filter(Boolean) as typeof allDuos;
+    }
+    return allDuos;
+  }, [status, finalists, allDuos]);
+
+  const pendingDuos = orderedDuos.filter((d) => !registeredIds.has(d.id));
+  const currentDuo = pendingDuos[0] ?? null;
+  const nextDuo = pendingDuos[1] ?? null;
+
+  // Última passada registrada
+  const lastResult = useMemo(() => {
+    const stageResults = activeResults.filter((r: PassResult) => r.stage === stage);
+    return stageResults[stageResults.length - 1] ?? null;
+  }, [activeResults, stage]);
+
+  const lastDuo = lastResult ? allDuos.find((d) => d.id === lastResult.duoId) : null;
+
+  const total = orderedDuos.length;
+  const done = registeredIds.size;
+  const remaining = total - done;
+
+  function formatTime(s: number, sat?: boolean) {
+    return sat ? 'SAT' : `${s.toFixed(2)}s`;
+  }
+
+  const stageLabel = status === 'final' ? 'Final' : 'Qualificatória';
+
+  return (
+    <div className="min-h-[60vh] flex flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-serif font-semibold text-rope-800">Visão do Locutor</h2>
+          <p className="text-sm text-rope-400">{stageLabel} · {competition?.name}</p>
+        </div>
+        <Button variant="outline" size="sm" onClick={requestFullscreen}>
+          Tela Cheia ⛶
+        </Button>
+      </div>
+
+      {/* Próxima e seguinte */}
+      <div className="grid gap-4 sm:grid-cols-2">
+        {/* Próxima dupla — destaque principal */}
+        <div className="rounded-2xl bg-saddle-800 text-white p-6 border border-saddle-700 shadow-lg">
+          <p className="text-saddle-300 text-xs uppercase tracking-widest mb-2">Próxima Passada</p>
+          {currentDuo ? (
+            <>
+              <p className="text-5xl font-bold font-serif text-hay-300 mb-2">
+                #{currentDuo.passNumber ?? '—'}
+              </p>
+              <p className="text-2xl font-semibold leading-tight mb-3">{currentDuo.label}</p>
+              <GroupBadge group={currentDuo.group} size="md" />
+            </>
+          ) : (
+            <p className="text-2xl text-saddle-300 font-semibold mt-2">
+              {total === 0 ? 'Sem duplas' : '✅ Etapa concluída!'}
+            </p>
+          )}
+        </div>
+
+        {/* Dupla seguinte — pré-anúncio */}
+        <div className="rounded-2xl bg-white p-6 border border-dust-300 shadow-sm">
+          <p className="text-rope-400 text-xs uppercase tracking-widest mb-2">Em Seguida</p>
+          {nextDuo ? (
+            <>
+              <p className="text-3xl font-bold font-serif text-saddle-600 mb-2">
+                #{nextDuo.passNumber ?? '—'}
+              </p>
+              <p className="text-xl font-semibold text-rope-800 leading-tight mb-3">{nextDuo.label}</p>
+              <GroupBadge group={nextDuo.group} size="md" />
+            </>
+          ) : (
+            <p className="text-rope-300 text-lg mt-2">—</p>
+          )}
+        </div>
+      </div>
+
+      {/* Última passada */}
+      {lastResult && lastDuo && (
+        <div className="rounded-xl bg-white border border-dust-300 p-5">
+          <p className="text-rope-400 text-xs uppercase tracking-widest mb-3">Última Passada</p>
+          <div className="flex flex-wrap items-center gap-4">
+            <div className="flex-1 min-w-0">
+              <p className="font-semibold text-rope-800 text-lg truncate">{lastDuo.label}</p>
+              <GroupBadge group={lastDuo.group} />
+            </div>
+            <div className="flex gap-6 text-center">
+              {lastResult.calledCattle !== undefined && (
+                <div>
+                  <p className="text-xs text-rope-400">Boi Cantado</p>
+                  <p className="text-2xl font-bold text-saddle-700">{lastResult.calledCattle}</p>
+                </div>
+              )}
+              <div>
+                <p className="text-xs text-rope-400">Bois</p>
+                <p className="text-2xl font-bold text-rope-800">{lastResult.cattleCount}</p>
+              </div>
+              <div>
+                <p className="text-xs text-rope-400">Tempo</p>
+                <p className="text-2xl font-bold text-rope-800">{formatTime(lastResult.timeSeconds, lastResult.isSAT)}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Estatísticas */}
+      <div className="grid grid-cols-3 gap-3">
+        <StatCard label="Total de Duplas" value={total} />
+        <StatCard label="Concluídas" value={done} highlight />
+        <StatCard label="Restantes" value={remaining} />
+      </div>
+    </div>
+  );
+}

--- a/src/screens/CompetitorHistory/index.tsx
+++ b/src/screens/CompetitorHistory/index.tsx
@@ -22,7 +22,7 @@ export default function CompetitorHistory() {
     () => allDuos.filter((d) => d.riderOneId === competitorId || d.riderTwoId === competitorId),
     [allDuos, competitorId]
   );
-  const myDuoIds = new Set(myDuos.map((d) => d.id));
+  const myDuoIds = useMemo(() => new Set(myDuos.map((d) => d.id)), [myDuos]);
 
   const qualResults = useMemo(
     () => results.filter((r) => r.stage === 'Qualifier' && myDuoIds.has(r.duoId)),

--- a/src/screens/CompetitorHistory/index.tsx
+++ b/src/screens/CompetitorHistory/index.tsx
@@ -1,0 +1,162 @@
+import React, { useMemo } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useResults } from 'context/ResultContext';
+import { useCompetition } from '../../context/CompetitionContext';
+import { Card } from '../../components/ui/Card';
+import { PageHeader } from '../../components/ui/PageHeader';
+import { GroupBadge } from '../../components/ui/Badge';
+import { EmptyState } from '../../components/ui/EmptyState';
+import { Button } from '../../components/ui/Button';
+
+export default function CompetitorHistory() {
+  const { competitorId } = useParams<{ competitorId: string }>();
+  const navigate = useNavigate();
+  const { results, finalResults, duosMeta } = useResults();
+  const { competitors, duos: compDuos } = useCompetition();
+
+  const allDuos = duosMeta.length > 0 ? duosMeta : compDuos;
+  const competitor = competitors.find((c) => c.id === competitorId);
+
+  // Duplas em que este competidor participou
+  const myDuos = useMemo(
+    () => allDuos.filter((d) => d.riderOneId === competitorId || d.riderTwoId === competitorId),
+    [allDuos, competitorId]
+  );
+  const myDuoIds = new Set(myDuos.map((d) => d.id));
+
+  const qualResults = useMemo(
+    () => results.filter((r) => r.stage === 'Qualifier' && myDuoIds.has(r.duoId)),
+    [results, myDuoIds]
+  );
+
+  const finResults = useMemo(
+    () => finalResults.filter((r) => r.stage === 'Final' && myDuoIds.has(r.duoId)),
+    [finalResults, myDuoIds]
+  );
+
+  function getDuo(duoId: string) {
+    return allDuos.find((d) => d.id === duoId);
+  }
+
+  function getPartnerName(duoId: string) {
+    const duo = getDuo(duoId);
+    if (!duo) return '?';
+    const partnerId = duo.riderOneId === competitorId ? duo.riderTwoId : duo.riderOneId;
+    return competitors.find((c) => c.id === partnerId)?.name ?? '?';
+  }
+
+  function getPassNumber(duoId: string) {
+    return getDuo(duoId)?.passNumber ?? '?';
+  }
+
+  // Estatísticas das qualificatórias
+  const qualStats = useMemo(() => {
+    if (qualResults.length === 0) return null;
+    const sats = qualResults.filter((r) => r.isSAT).length;
+    const avgCattle = qualResults.reduce((s, r) => s + r.cattleCount, 0) / qualResults.length;
+    const avgTime = qualResults.reduce((s, r) => s + r.timeSeconds, 0) / qualResults.length;
+    return { sats, avgCattle, avgTime };
+  }, [qualResults]);
+
+  function formatTime(s: number, sat?: boolean) {
+    return sat ? 'SAT' : `${s.toFixed(2)}s`;
+  }
+
+  if (!competitor) {
+    return (
+      <div className="py-10">
+        <EmptyState icon="👤" title="Competidor não encontrado" description="Verifique o link e tente novamente." action={<Button variant="outline" onClick={() => navigate(-1)}>← Voltar</Button>} />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <PageHeader
+        title={`Histórico — ${competitor.name}`}
+        subtitle={`${qualResults.length} passada${qualResults.length !== 1 ? 's' : ''} nas qualificatórias · ${finResults.length} na final`}
+        backTo=""
+        actions={<Button variant="outline" size="sm" onClick={() => navigate(-1)}>← Voltar</Button>}
+      />
+
+      {/* Qualificatórias */}
+      <div className="flex flex-col gap-5">
+        <Card title={`Qualificatórias (${qualResults.length})`} noPadding>
+          {qualResults.length === 0 ? (
+            <EmptyState icon="📋" title="Sem passadas registradas" />
+          ) : (
+            <>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead className="bg-dust-50 border-b border-dust-200">
+                    <tr>
+                      <th className="px-4 py-2.5 text-left text-xs font-semibold text-rope-500">Passada</th>
+                      <th className="px-4 py-2.5 text-left text-xs font-semibold text-rope-500">Parceiro</th>
+                      <th className="px-4 py-2.5 text-center text-xs font-semibold text-rope-500">Grp</th>
+                      <th className="px-4 py-2.5 text-center text-xs font-semibold text-rope-500">B.Cant.</th>
+                      <th className="px-4 py-2.5 text-center text-xs font-semibold text-rope-500">Bois</th>
+                      <th className="px-4 py-2.5 text-center text-xs font-semibold text-rope-500">Tempo</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-dust-100">
+                    {qualResults.map((r) => (
+                      <tr key={r.id} className={r.isSAT ? 'bg-brand-50' : 'hover:bg-dust-50'}>
+                        <td className="px-4 py-2.5 text-rope-500 text-xs font-mono">#{getPassNumber(r.duoId)}</td>
+                        <td className="px-4 py-2.5 font-medium text-rope-800 text-sm">{getPartnerName(r.duoId)}</td>
+                        <td className="px-4 py-2.5 text-center"><GroupBadge group={getDuo(r.duoId)?.group ?? '1D'} /></td>
+                        <td className="px-4 py-2.5 text-center text-rope-500 text-sm">{r.calledCattle ?? '—'}</td>
+                        <td className="px-4 py-2.5 text-center font-semibold text-rope-700">{r.cattleCount}</td>
+                        <td className="px-4 py-2.5 text-center text-rope-600 text-sm">{formatTime(r.timeSeconds, r.isSAT)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              {qualStats && (
+                <div className="px-4 py-3 bg-dust-50 border-t border-dust-200 flex flex-wrap gap-4 text-xs text-rope-600">
+                  <span>Média bois: <strong className="text-rope-800">{qualStats.avgCattle.toFixed(2)}</strong></span>
+                  <span>Tempo médio: <strong className="text-rope-800">{formatTime(qualStats.avgTime)}</strong></span>
+                  <span>SATs: <strong className="text-brand-600">{qualStats.sats}</strong></span>
+                </div>
+              )}
+            </>
+          )}
+        </Card>
+
+        {/* Finais */}
+        <Card title={`Final (${finResults.length})`} noPadding>
+          {finResults.length === 0 ? (
+            <EmptyState icon="🏆" title="Sem passadas na final" />
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="bg-dust-50 border-b border-dust-200">
+                  <tr>
+                    <th className="px-4 py-2.5 text-left text-xs font-semibold text-rope-500">Passada</th>
+                    <th className="px-4 py-2.5 text-left text-xs font-semibold text-rope-500">Parceiro</th>
+                    <th className="px-4 py-2.5 text-center text-xs font-semibold text-rope-500">Grp</th>
+                    <th className="px-4 py-2.5 text-center text-xs font-semibold text-rope-500">B.Cant.</th>
+                    <th className="px-4 py-2.5 text-center text-xs font-semibold text-rope-500">Bois</th>
+                    <th className="px-4 py-2.5 text-center text-xs font-semibold text-rope-500">Tempo</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-dust-100">
+                  {finResults.map((r) => (
+                    <tr key={r.id} className={r.isSAT ? 'bg-brand-50' : 'hover:bg-dust-50'}>
+                      <td className="px-4 py-2.5 text-rope-500 text-xs font-mono">#{getPassNumber(r.duoId)}</td>
+                      <td className="px-4 py-2.5 font-medium text-rope-800 text-sm">{getPartnerName(r.duoId)}</td>
+                      <td className="px-4 py-2.5 text-center"><GroupBadge group={getDuo(r.duoId)?.group ?? '1D'} /></td>
+                      <td className="px-4 py-2.5 text-center text-rope-500 text-sm">{r.calledCattle ?? '—'}</td>
+                      <td className="px-4 py-2.5 text-center font-semibold text-rope-700">{r.cattleCount}</td>
+                      <td className="px-4 py-2.5 text-center text-rope-600 text-sm">{formatTime(r.timeSeconds, r.isSAT)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/screens/Duos/index.tsx
+++ b/src/screens/Duos/index.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useResults } from 'context/ResultContext';
 import { useCompetition } from '../../context/CompetitionContext';
 import { useToast } from '../../components/ui/Toast';
+import { useSubscription } from '../../hooks/useSubscription';
 import { exportToExcel } from 'utils/exportExcel';
 import { importDuosFromExcel } from 'utils/importExcel';
 import { Button } from '../../components/ui/Button';
@@ -15,10 +16,10 @@ export default function Duos() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const toast = useToast();
+  const { isPro } = useSubscription();
   const { setDuosMeta } = useResults();
   const { competitors, duos, setDuos, setCompetitors: setCompetitorsCtx } = useCompetition();
 
-  // importDuosFromExcel expects a React dispatch; wrap our setter
   const setCompetitors: React.Dispatch<React.SetStateAction<typeof competitors>> = (
     value
   ) => {
@@ -44,20 +45,44 @@ export default function Duos() {
     }
   }
 
-  function handleExport() {
+  function handleExportGeral() {
     exportToExcel(
-      duos.map((duo) => {
+      duos.map((duo, idx) => {
         const a = competitors.find((c) => c.id === duo.riderOneId);
         const b = competitors.find((c) => c.id === duo.riderTwoId);
         return {
+          'Nº Passada': duo.passNumber ?? idx + 1,
           Dupla: `${a?.name ?? '?'} & ${b?.name ?? '?'}`,
           Categoria: duo.group,
-          Categoria_A: a?.category ?? '',
-          Categoria_B: b?.category ?? '',
+          'Cat. A': a?.category ?? '',
+          'Cat. B': b?.category ?? '',
         };
       }),
-      'Duplas_Cadastradas'
+      'Duplas_Sorteio'
     );
+  }
+
+  function handleExportPorCompetidor() {
+    const rows: { Competidor: string; 'Nº Passada': number; Dupla: string; Categoria: string }[] = [];
+
+    for (const comp of competitors) {
+      const myDuos = duos.filter(
+        (d) => d.riderOneId === comp.id || d.riderTwoId === comp.id
+      );
+      for (const duo of myDuos) {
+        const partner = competitors.find(
+          (c) => c.id === (duo.riderOneId === comp.id ? duo.riderTwoId : duo.riderOneId)
+        );
+        rows.push({
+          Competidor: comp.name,
+          'Nº Passada': duo.passNumber ?? 0,
+          Dupla: duo.label ?? `${comp.name} & ${partner?.name ?? '?'}`,
+          Categoria: duo.group,
+        });
+      }
+    }
+    rows.sort((a, b) => a.Competidor.localeCompare(b.Competidor, 'pt-BR') || a['Nº Passada'] - b['Nº Passada']);
+    exportToExcel(rows, 'Duplas_Por_Competidor');
   }
 
   function DuoList({ items }: { items: typeof duos }) {
@@ -66,11 +91,14 @@ export default function Duos() {
         {items.map((duo, i) => {
           const a = competitors.find((c) => c.id === duo.riderOneId);
           const b = competitors.find((c) => c.id === duo.riderTwoId);
+          const passNum = duo.passNumber ?? i + 1;
           return (
-            <li key={duo.id} className="px-5 py-3 flex items-center gap-3">
-              <span className="text-rope-400 text-xs w-6 text-right shrink-0">{i + 1}.</span>
+            <li key={duo.id} className="px-4 py-3 flex items-center gap-3">
+              <span className="text-rope-400 text-xs w-8 text-right shrink-0 font-mono">
+                {passNum}.
+              </span>
               <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2 flex-wrap">
+                <div className="flex items-center gap-1.5 flex-wrap">
                   <span className="font-medium text-rope-800 text-sm">{a?.name ?? '?'}</span>
                   {a && <CategoryBadge category={a.category} />}
                   <span className="text-rope-400 text-sm font-bold">&amp;</span>
@@ -92,9 +120,18 @@ export default function Duos() {
         title="Duplas"
         subtitle={`${duos.length} dupla${duos.length !== 1 ? 's' : ''} sorteada${duos.length !== 1 ? 's' : ''} · ${duos1D.length} na 1D · ${duos2D.length} na 2D`}
         actions={
-          <div className="flex gap-2">
-            <Button variant="outline" size="sm" onClick={handleExport} disabled={duos.length === 0}>
-              Exportar Excel
+          <div className="flex flex-wrap gap-2">
+            <Button variant="outline" size="sm" onClick={handleExportGeral} disabled={duos.length === 0}>
+              Exportar Lista
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={isPro ? handleExportPorCompetidor : undefined}
+              disabled={duos.length === 0}
+              title={isPro ? 'Exportar por competidor' : 'Disponível no plano Pro'}
+            >
+              Por Competidor {!isPro && '🔒'}
             </Button>
             <Button variant="secondary" size="sm" onClick={() => fileRef.current?.click()}>
               Importar Excel
@@ -124,12 +161,12 @@ export default function Duos() {
       ) : (
         <div className="flex flex-col gap-5">
           {duos1D.length > 0 && (
-            <Card title={`Grupo 1D — Aberta (${duos1D.length} duplas)`} noPadding>
+            <Card title={`Grupo 1D — Profissional (${duos1D.length} duplas)`} noPadding>
               <DuoList items={duos1D} />
             </Card>
           )}
           {duos2D.length > 0 && (
-            <Card title={`Grupo 2D — Demais categorias (${duos2D.length} duplas)`} noPadding>
+            <Card title={`Grupo 2D — Amador (${duos2D.length} duplas)`} noPadding>
               <DuoList items={duos2D} />
             </Card>
           )}

--- a/src/screens/Duos/index.tsx
+++ b/src/screens/Duos/index.tsx
@@ -50,7 +50,7 @@ export default function Duos() {
         const a = competitors.find((c) => c.id === duo.riderOneId);
         const b = competitors.find((c) => c.id === duo.riderTwoId);
         return {
-          Dupla: `${a?.name ?? '?'} 🤝 ${b?.name ?? '?'}`,
+          Dupla: `${a?.name ?? '?'} & ${b?.name ?? '?'}`,
           Categoria: duo.group,
           Categoria_A: a?.category ?? '',
           Categoria_B: b?.category ?? '',
@@ -73,7 +73,7 @@ export default function Duos() {
                 <div className="flex items-center gap-2 flex-wrap">
                   <span className="font-medium text-rope-800 text-sm">{a?.name ?? '?'}</span>
                   {a && <CategoryBadge category={a.category} />}
-                  <span className="text-rope-400 text-sm">🤝</span>
+                  <span className="text-rope-400 text-sm font-bold">&amp;</span>
                   <span className="font-medium text-rope-800 text-sm">{b?.name ?? '?'}</span>
                   {b && <CategoryBadge category={b.category} />}
                 </div>

--- a/src/screens/Final/index.tsx
+++ b/src/screens/Final/index.tsx
@@ -12,6 +12,7 @@ import { GroupBadge } from '../../components/ui/Badge';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { PageHeader } from '../../components/ui/PageHeader';
 import { UpgradeBadge, UpgradeModal } from '../../components/ui/UpgradePrompt';
+import { QuickSelect } from '../../components/ui/QuickSelect';
 
 type PendingEntry = {
   duoId: string;
@@ -20,6 +21,9 @@ type PendingEntry = {
   cattleCount: number;
   timeSeconds: number;
 };
+
+type FormState = { cattle: number | null; calledCattle: number | null; time: string };
+const emptyForm = (): FormState => ({ cattle: null, calledCattle: null, time: '' });
 
 export default function Finals() {
   const { id } = useParams<{ id: string }>();
@@ -34,12 +38,10 @@ export default function Finals() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const bestScores = useMemo(() => getBestQualifierScores(), [finalResults]);
 
-  const [forms, setForms] = useState({
-    '1D': { cattleCount: '', timeSeconds: '' },
-    '2D': { cattleCount: '', timeSeconds: '' },
-  });
-  const [activeTab, setActiveTab] = useState<'1D' | '2D'>('1D');
-  const [formErrors, setFormErrors] = useState<{ cattle?: string; time?: string }>({});
+  // Default: 2D vai primeiro
+  const [activeTab, setActiveTab] = useState<'1D' | '2D'>('2D');
+  const [forms, setForms] = useState<Record<'1D' | '2D', FormState>>({ '1D': emptyForm(), '2D': emptyForm() });
+  const [timeError, setTimeError] = useState('');
 
   function toPendingEntries(entries: Array<{ duoId: string; cattleCount: number; timeSeconds: number }>): PendingEntry[] {
     return entries.map((e) => {
@@ -55,7 +57,6 @@ export default function Finals() {
   }
 
   function getPendingList(category: '1D' | '2D'): PendingEntry[] {
-    // Worst qualifier first → best qualifier last (runs last in finals)
     const sorted = category === '1D'
       ? [...finalists.finalists1D].reverse()
       : [...finalists.finalists2D].reverse();
@@ -67,9 +68,9 @@ export default function Finals() {
   const pending1D = getPendingList('1D');
   const pending2D = getPendingList('2D');
   const pendingActive = activeTab === '1D' ? pending1D : pending2D;
-  // First in list = worst qualifier = runs next
   const currentDuo = pendingActive[0] ?? null;
   const currentForm = forms[activeTab];
+  const is2DComplete = pending2D.length === 0 && finalists.finalists2D.length > 0;
 
   const partials = useMemo(() => {
     return finalResults
@@ -86,6 +87,7 @@ export default function Finals() {
           qualiTime: quali.timeSeconds,
           finalCattle: r.cattleCount,
           finalTime: r.timeSeconds,
+          calledCattle: r.calledCattle,
           avgCattle: (quali.cattleCount + r.cattleCount) / 2,
           avgTime: (quali.timeSeconds + r.timeSeconds) / 2,
         };
@@ -94,30 +96,39 @@ export default function Finals() {
   }, [finalResults, bestScores, duosMeta]); // eslint-disable-line react-hooks/exhaustive-deps
 
   function validateForm() {
-    const e: typeof formErrors = {};
-    const cattle = Number(currentForm.cattleCount);
-    const time = Number(currentForm.timeSeconds);
-    if (currentForm.cattleCount === '' || isNaN(cattle) || cattle < 0 || cattle > 10) e.cattle = 'Bois: 0 a 10';
-    if (currentForm.timeSeconds === '' || isNaN(time) || time <= 0) e.time = 'Tempo inválido';
-    setFormErrors(e);
-    return Object.keys(e).length === 0;
+    if (currentForm.cattle === null) {
+      toast('Selecione a quantidade de bois.', 'error');
+      return false;
+    }
+    const t = Number(currentForm.time);
+    if (!currentForm.time || isNaN(t) || t <= 0) {
+      setTimeError('Tempo inválido');
+      return false;
+    }
+    setTimeError('');
+    return true;
   }
 
   function saveFinalResult(isSAT = false) {
     if (!currentDuo) return;
     if (!isSAT && !validateForm()) return;
-    const cattle = isSAT ? 0 : Number(currentForm.cattleCount);
-    const time = isSAT ? 120 : Number(currentForm.timeSeconds);
-    addFinalResult(currentDuo.duoId, cattle, time, isSAT);
-    setForms({ ...forms, [activeTab]: { cattleCount: '', timeSeconds: '' } });
-    setFormErrors({});
-    toast(isSAT ? `SAT registrado!` : `Resultado salvo!`, 'success');
+    const c = isSAT ? 0 : currentForm.cattle!;
+    const t = isSAT ? 120 : Number(currentForm.time);
+    addFinalResult(currentDuo.duoId, c, t, isSAT, currentForm.calledCattle ?? undefined);
+    setForms({ ...forms, [activeTab]: emptyForm() });
+    setTimeError('');
+    toast(isSAT ? 'SAT registrado!' : 'Resultado salvo!', 'success');
   }
 
   function handleTabChange(tab: '1D' | '2D') {
     setActiveTab(tab);
-    setForms({ ...forms, [tab]: { cattleCount: '', timeSeconds: '' } });
-    setFormErrors({});
+    setForms({ ...forms, [tab]: emptyForm() });
+    setTimeError('');
+  }
+
+  function setFormField(field: keyof FormState, value: any) {
+    setForms({ ...forms, [activeTab]: { ...currentForm, [field]: value } });
+    if (field === 'time') setTimeError('');
   }
 
   function formatTime(s: number) {
@@ -132,7 +143,7 @@ export default function Finals() {
         title="Final"
         subtitle={`${finalists.finalists1D.length} finalistas 1D · ${finalists.finalists2D.length} finalistas 2D`}
         actions={
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 flex-wrap">
             {!isPro && <UpgradeBadge />}
             <Button
               variant="outline"
@@ -145,6 +156,7 @@ export default function Finals() {
                           '#': idx + 1,
                           Dupla: p?.label,
                           Grupo: p?.group,
+                          'Boi Cantado': p?.calledCattle ?? '',
                           'Bois Qualif.': p?.qualiCattle,
                           'Tempo Qualif.': p?.qualiTime?.toFixed(2),
                           'Bois Final': p?.finalCattle,
@@ -166,25 +178,33 @@ export default function Finals() {
         }
       />
 
-      {/* Tabs */}
+      {/* Tabs — 2D primeiro, 1D bloqueada até 2D encerrar */}
       <div className="flex gap-0 mb-5 bg-white rounded-xl border border-dust-300 p-1 w-fit">
-        {(['1D', '2D'] as const).map((tab) => (
-          <button
-            key={tab}
-            onClick={() => handleTabChange(tab)}
-            className={[
-              'px-5 py-2 rounded-lg text-sm font-semibold transition-all',
-              activeTab === tab
-                ? 'bg-saddle-600 text-white shadow-sm'
-                : 'text-rope-500 hover:text-rope-800',
-            ].join(' ')}
-          >
-            Categoria {tab}
-            <span className={`ml-1.5 text-xs rounded-full px-1.5 py-0.5 ${activeTab === tab ? 'bg-saddle-500 text-white' : 'bg-dust-200 text-rope-400'}`}>
-              {tab === '1D' ? finalists.finalists1D.length : finalists.finalists2D.length}
-            </span>
-          </button>
-        ))}
+        {(['2D', '1D'] as const).map((tab) => {
+          const isBlocked = tab === '1D' && !is2DComplete && finalists.finalists2D.length > 0;
+          return (
+            <button
+              key={tab}
+              onClick={() => !isBlocked && handleTabChange(tab)}
+              disabled={isBlocked}
+              title={isBlocked ? 'Aguarde o encerramento da categoria 2D' : undefined}
+              className={[
+                'px-5 py-2 rounded-lg text-sm font-semibold transition-all',
+                activeTab === tab
+                  ? 'bg-saddle-600 text-white shadow-sm'
+                  : isBlocked
+                  ? 'text-rope-300 cursor-not-allowed'
+                  : 'text-rope-500 hover:text-rope-800',
+              ].join(' ')}
+            >
+              Categoria {tab}
+              <span className={`ml-1.5 text-xs rounded-full px-1.5 py-0.5 ${activeTab === tab ? 'bg-saddle-500 text-white' : 'bg-dust-200 text-rope-400'}`}>
+                {tab === '1D' ? finalists.finalists1D.length : finalists.finalists2D.length}
+              </span>
+              {isBlocked && <span className="ml-1 text-xs">🔒</span>}
+            </button>
+          );
+        })}
       </div>
 
       <div className="grid gap-5 lg:grid-cols-5">
@@ -203,27 +223,36 @@ export default function Finals() {
                 </div>
               </div>
 
-              <div className="flex flex-col gap-3">
-                <div>
-                  <label className="text-sm font-medium text-rope-700 block mb-1">Bois (0–10)</label>
-                  <input
-                    type="number" min={0} max={10} placeholder="0"
-                    value={currentForm.cattleCount}
-                    onChange={(e) => { setForms({ ...forms, [activeTab]: { ...currentForm, cattleCount: e.target.value } }); setFormErrors({}); }}
-                    className={`w-full px-3 py-2 rounded-lg border text-sm focus:outline-none focus:ring-2 focus:ring-hay-400 ${formErrors.cattle ? 'border-brand-500' : 'border-dust-300'}`}
-                  />
-                  {formErrors.cattle && <p className="text-xs text-brand-500 mt-0.5">{formErrors.cattle}</p>}
-                </div>
+              <div className="flex flex-col gap-4">
+                <QuickSelect
+                  label="Boi Cantado (0–9)"
+                  value={currentForm.calledCattle}
+                  onChange={(v) => setFormField('calledCattle', v)}
+                  min={0}
+                  max={9}
+                  cols={5}
+                />
+
+                <QuickSelect
+                  label="Quantidade de Bois (0–10)"
+                  value={currentForm.cattle}
+                  onChange={(v) => setFormField('cattle', v)}
+                  min={0}
+                  max={10}
+                  cols={6}
+                />
+
                 <div>
                   <label className="text-sm font-medium text-rope-700 block mb-1">Tempo (segundos)</label>
                   <input
                     type="number" min={0.01} step={0.01} placeholder="45.5"
-                    value={currentForm.timeSeconds}
-                    onChange={(e) => { setForms({ ...forms, [activeTab]: { ...currentForm, timeSeconds: e.target.value } }); setFormErrors({}); }}
-                    className={`w-full px-3 py-2 rounded-lg border text-sm focus:outline-none focus:ring-2 focus:ring-hay-400 ${formErrors.time ? 'border-brand-500' : 'border-dust-300'}`}
+                    value={currentForm.time}
+                    onChange={(e) => setFormField('time', e.target.value)}
+                    className={`w-full px-3 py-2 rounded-lg border text-sm focus:outline-none focus:ring-2 focus:ring-hay-400 ${timeError ? 'border-brand-500' : 'border-dust-300'}`}
                   />
-                  {formErrors.time && <p className="text-xs text-brand-500 mt-0.5">{formErrors.time}</p>}
+                  {timeError && <p className="text-xs text-brand-500 mt-0.5">{timeError}</p>}
                 </div>
+
                 <div className="flex gap-2">
                   <Button onClick={() => saveFinalResult(false)} fullWidth>Salvar</Button>
                   <Button onClick={() => saveFinalResult(true)} variant="danger" title="SAT">SAT</Button>
@@ -234,12 +263,10 @@ export default function Finals() {
             <Card>
               <div className="text-center py-4">
                 <div className="text-4xl mb-2">✅</div>
-                <p className="font-semibold text-pasture-700">
-                  Categoria {activeTab} completa!
-                </p>
-                {activeTab === '1D' && pending2D.length > 0 && (
-                  <Button className="mt-3" size="sm" onClick={() => handleTabChange('2D')}>
-                    Ir para 2D →
+                <p className="font-semibold text-pasture-700">Categoria {activeTab} completa!</p>
+                {activeTab === '2D' && pending1D.length > 0 && (
+                  <Button className="mt-3" size="sm" onClick={() => handleTabChange('1D')}>
+                    Ir para 1D →
                   </Button>
                 )}
               </div>
@@ -260,7 +287,7 @@ export default function Finals() {
             </Card>
           )}
 
-          {pending1D.length === 0 && pending2D.length === 0 && (
+          {pending1D.length === 0 && pending2D.length === 0 && finalists.finalists1D.length > 0 && (
             <Button onClick={() => navigate(`/competition/${id}/final-results`)} size="lg" fullWidth>
               Ver Resultados Finais →
             </Button>
@@ -276,14 +303,15 @@ export default function Finals() {
               <table className="w-full text-sm">
                 <thead className="bg-dust-50 border-b border-dust-200">
                   <tr>
-                    <th className="px-3 py-2.5 text-left text-xs font-semibold text-rope-500 uppercase tracking-wide">#</th>
-                    <th className="px-3 py-2.5 text-left text-xs font-semibold text-rope-500 uppercase tracking-wide">Dupla</th>
-                    <th className="px-3 py-2.5 text-center text-xs font-semibold text-rope-500 uppercase tracking-wide">Q.B</th>
-                    <th className="px-3 py-2.5 text-center text-xs font-semibold text-rope-500 uppercase tracking-wide">Q.T</th>
-                    <th className="px-3 py-2.5 text-center text-xs font-semibold text-rope-500 uppercase tracking-wide">F.B</th>
-                    <th className="px-3 py-2.5 text-center text-xs font-semibold text-rope-500 uppercase tracking-wide">F.T</th>
-                    <th className="px-3 py-2.5 text-center text-xs font-semibold text-rope-500 uppercase tracking-wide">Méd.B</th>
-                    <th className="px-3 py-2.5 text-center text-xs font-semibold text-rope-500 uppercase tracking-wide">Méd.T</th>
+                    <th className="px-3 py-2.5 text-left text-xs font-semibold text-rope-500 uppercase">#</th>
+                    <th className="px-3 py-2.5 text-left text-xs font-semibold text-rope-500 uppercase">Dupla</th>
+                    <th className="px-3 py-2.5 text-center text-xs font-semibold text-rope-500 uppercase">B.C</th>
+                    <th className="px-3 py-2.5 text-center text-xs font-semibold text-rope-500 uppercase hidden sm:table-cell">Q.B</th>
+                    <th className="px-3 py-2.5 text-center text-xs font-semibold text-rope-500 uppercase hidden sm:table-cell">Q.T</th>
+                    <th className="px-3 py-2.5 text-center text-xs font-semibold text-rope-500 uppercase">F.B</th>
+                    <th className="px-3 py-2.5 text-center text-xs font-semibold text-rope-500 uppercase">F.T</th>
+                    <th className="px-3 py-2.5 text-center text-xs font-semibold text-rope-500 uppercase hidden sm:table-cell">Méd.B</th>
+                    <th className="px-3 py-2.5 text-center text-xs font-semibold text-rope-500 uppercase hidden sm:table-cell">Méd.T</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-dust-100">
@@ -298,18 +326,19 @@ export default function Finals() {
                           {idx === 0 ? '🥇' : idx === 1 ? '🥈' : idx === 2 ? '🥉' : idx + 1}
                         </td>
                         <td className="px-3 py-2.5 font-medium text-rope-800 text-xs max-w-[120px] truncate">{p?.label}</td>
-                        <td className="px-3 py-2.5 text-center text-rope-600 text-xs">{p?.qualiCattle}</td>
-                        <td className="px-3 py-2.5 text-center text-rope-600 text-xs">{formatTime(p?.qualiTime ?? 0)}</td>
+                        <td className="px-3 py-2.5 text-center text-rope-500 text-xs">{p?.calledCattle ?? '—'}</td>
+                        <td className="px-3 py-2.5 text-center text-rope-600 text-xs hidden sm:table-cell">{p?.qualiCattle}</td>
+                        <td className="px-3 py-2.5 text-center text-rope-600 text-xs hidden sm:table-cell">{formatTime(p?.qualiTime ?? 0)}</td>
                         <td className="px-3 py-2.5 text-center font-semibold text-rope-800 text-xs">{p?.finalCattle}</td>
                         <td className="px-3 py-2.5 text-center text-rope-600 text-xs">{formatTime(p?.finalTime ?? 0)}</td>
-                        <td className="px-3 py-2.5 text-center font-bold text-saddle-700 text-xs">{p?.avgCattle?.toFixed(1)}</td>
-                        <td className="px-3 py-2.5 text-center text-rope-600 text-xs">{p?.avgTime?.toFixed(2)}s</td>
+                        <td className="px-3 py-2.5 text-center font-bold text-saddle-700 text-xs hidden sm:table-cell">{p?.avgCattle?.toFixed(1)}</td>
+                        <td className="px-3 py-2.5 text-center text-rope-600 text-xs hidden sm:table-cell">{p?.avgTime?.toFixed(2)}s</td>
                       </tr>
                     ))}
                 </tbody>
               </table>
               <div className="px-4 py-2 bg-dust-50 border-t border-dust-200 text-xs text-rope-400">
-                Q.B = Bois Qualif. · Q.T = Tempo Qualif. · F.B = Bois Final · F.T = Tempo Final
+                B.C = Boi Cantado · Q.B = Bois Qualif. · F.B = Bois Final · F.T = Tempo Final
               </div>
             </div>
           )}

--- a/src/screens/FinalResults/index.tsx
+++ b/src/screens/FinalResults/index.tsx
@@ -81,7 +81,7 @@ export default function FinalResults() {
                     ].join(' ')}
                   >
                     <td className="px-4 py-3 text-lg text-center w-12">{medal(idx + 1)}</td>
-                    <td className="px-4 py-3 font-semibold text-rope-800">{r.duoLabel}</td>
+                    <td className="px-4 py-3 font-semibold text-rope-800 max-w-[160px] truncate">{r.duoLabel}</td>
                     <td className="px-4 py-3 text-center"><GroupBadge group={r.group} size="md" /></td>
                     <td className="px-4 py-3 text-center">
                       <span className="font-bold text-saddle-700 text-base">{r.totalCattle}</span>

--- a/src/screens/Qualifiers/index.tsx
+++ b/src/screens/Qualifiers/index.tsx
@@ -14,8 +14,9 @@ import { GroupBadge } from '../../components/ui/Badge';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { PageHeader } from '../../components/ui/PageHeader';
 import { UpgradeBadge, UpgradeModal } from '../../components/ui/UpgradePrompt';
+import { QuickSelect } from '../../components/ui/QuickSelect';
 
-type PartialRow = DuoScore & { duoLabel: string; isSAT?: boolean };
+type PartialRow = DuoScore & { duoLabel: string; isSAT?: boolean; calledCattle?: number };
 
 export default function Qualifiers() {
   const { id } = useParams<{ id: string }>();
@@ -26,13 +27,18 @@ export default function Qualifiers() {
   const { addQualifierResult, updateQualifierResult, results, duosMeta } = useResults();
   const { duos: compDuos } = useCompetition();
 
-  const [form, setForm] = useState({ cattleCount: '', timeSeconds: '' });
-  const [formErrors, setFormErrors] = useState<{ cattle?: string; time?: string }>({});
+  const [cattle, setCattle] = useState<number | null>(null);
+  const [calledCattle, setCalledCattle] = useState<number | null>(null);
+  const [timeSeconds, setTimeSeconds] = useState('');
+  const [timeError, setTimeError] = useState('');
+
   const [editingId, setEditingId] = useState<string | null>(null);
-  const [editForm, setEditForm] = useState({ cattleCount: '', timeSeconds: '' });
+  const [editCattle, setEditCattle] = useState<number | null>(null);
+  const [editCalledCattle, setEditCalledCattle] = useState<number | null>(null);
+  const [editTime, setEditTime] = useState('');
 
   const metaDuos = duosMeta.length > 0 ? duosMeta : compDuos;
-  const duos = metaDuos.map((d, index) => ({ ...d, number: index + 1 }));
+  const duos = metaDuos.map((d, index) => ({ ...d, number: d.passNumber ?? index + 1 }));
 
   const registeredDuoIds = new Set(
     results.filter((r: PassResult) => r.stage === 'Qualifier').map((r) => r.duoId)
@@ -52,57 +58,57 @@ export default function Qualifiers() {
         cattleCount: r.cattleCount,
         timeSeconds: r.timeSeconds,
         isSAT: r.isSAT,
+        calledCattle: r.calledCattle,
       };
     })
     .sort((a, b) => compareByScore(a, b));
 
+  // Separação para regra de ranking 2D
+  const partials1D = partials.filter((p) => p.group === '1D');
+  const partials2D = partials.filter((p) => p.group === '2D');
+  const show2D = partials1D.length >= 10;
+
   function validateForm() {
-    const e: typeof formErrors = {};
-    const cattle = Number(form.cattleCount);
-    const time = Number(form.timeSeconds);
-    if (form.cattleCount === '' || isNaN(cattle) || cattle < 0 || cattle > 10) {
-      e.cattle = 'Bois: 0 a 10';
+    if (cattle === null) {
+      toast('Selecione a quantidade de bois.', 'error');
+      return false;
     }
-    if (form.timeSeconds === '' || isNaN(time) || time <= 0) {
-      e.time = 'Tempo inválido';
+    const t = Number(timeSeconds);
+    if (!timeSeconds || isNaN(t) || t <= 0) {
+      setTimeError('Tempo inválido');
+      return false;
     }
-    setFormErrors(e);
-    return Object.keys(e).length === 0;
+    setTimeError('');
+    return true;
   }
 
   function saveQualifierResult(isSAT = false) {
     if (!currentDuo) return;
     if (!isSAT && !validateForm()) return;
 
-    const cattle = isSAT ? 0 : Number(form.cattleCount);
-    const time = isSAT ? 120 : Number(form.timeSeconds);
+    const c = isSAT ? 0 : cattle!;
+    const t = isSAT ? 120 : Number(timeSeconds);
 
-    addQualifierResult(currentDuo.id, cattle, time, isSAT);
-    setForm({ cattleCount: '', timeSeconds: '' });
-    setFormErrors({});
-    toast(isSAT ? `SAT registrado para ${currentDuo.label}` : `Resultado salvo!`, 'success');
+    addQualifierResult(currentDuo.id, c, t, isSAT, calledCattle ?? undefined);
+    setCattle(null);
+    setCalledCattle(null);
+    setTimeSeconds('');
+    setTimeError('');
+    toast(isSAT ? `SAT registrado para ${currentDuo.label}` : 'Resultado salvo!', 'success');
   }
 
-  function startEdit(row: PartialRow & { isSAT?: boolean }) {
+  function startEdit(row: PartialRow) {
     setEditingId(row.duoId);
-    setEditForm({
-      cattleCount: row.cattleCount.toString(),
-      timeSeconds: row.timeSeconds.toString(),
-    });
+    setEditCattle(row.cattleCount);
+    setEditCalledCattle(row.calledCattle ?? null);
+    setEditTime(row.timeSeconds.toString());
   }
 
   function saveEdit(duoId: string) {
-    const cattle = Number(editForm.cattleCount);
-    const time = Number(editForm.timeSeconds);
-    if (isNaN(cattle) || cattle < 0 || cattle > 10) {
-      toast('Bois inválido (0–10)', 'error');
-      return;
-    }
-    if (isNaN(time) || time <= 0) {
-      toast('Tempo inválido', 'error');
-      return;
-    }
-    updateQualifierResult(duoId, cattle, time);
+    if (editCattle === null) { toast('Selecione a quantidade de bois', 'error'); return; }
+    const t = Number(editTime);
+    if (isNaN(t) || t <= 0) { toast('Tempo inválido', 'error'); return; }
+    updateQualifierResult(duoId, editCattle, t, editCalledCattle ?? undefined);
     setEditingId(null);
     toast('Resultado atualizado!', 'success');
   }
@@ -111,6 +117,68 @@ export default function Qualifiers() {
 
   function formatTime(s: number, sat?: boolean) {
     return sat ? 'SAT' : `${s.toFixed(2)}s`;
+  }
+
+  function RankingTable({ rows, title }: { rows: PartialRow[]; title: string }) {
+    return (
+      <div>
+        <h3 className="text-xs font-semibold text-rope-500 uppercase tracking-wide px-4 py-2 border-b border-dust-200 bg-dust-50">
+          {title}
+        </h3>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="bg-dust-50 border-b border-dust-200">
+              <tr>
+                <th className="px-3 py-2 text-left text-xs font-semibold text-rope-500">#</th>
+                <th className="px-3 py-2 text-left text-xs font-semibold text-rope-500">Dupla</th>
+                <th className="px-3 py-2 text-center text-xs font-semibold text-rope-500">B.Cant.</th>
+                <th className="px-3 py-2 text-center text-xs font-semibold text-rope-500">Bois</th>
+                <th className="px-3 py-2 text-center text-xs font-semibold text-rope-500">Tempo</th>
+                <th className="px-3 py-2 text-center text-xs font-semibold text-rope-500"></th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-dust-100">
+              {rows.map((p, idx) => (
+                <tr key={p.duoId} className="hover:bg-dust-50 transition-colors">
+                  <td className="px-3 py-2 text-rope-400 text-xs">{idx + 1}</td>
+                  <td className="px-3 py-2 font-medium text-rope-800 text-xs max-w-[140px] truncate">{p.duoLabel}</td>
+                  {editingId === p.duoId ? (
+                    <>
+                      <td className="px-2 py-1.5">
+                        <input type="number" min={0} max={9} value={editCalledCattle ?? ''} onChange={(e) => setEditCalledCattle(e.target.value ? Number(e.target.value) : null)} className="w-14 px-2 py-1 border border-hay-400 rounded text-sm text-center focus:outline-none" />
+                      </td>
+                      <td className="px-2 py-1.5">
+                        <input type="number" min={0} max={10} value={editCattle ?? ''} onChange={(e) => setEditCattle(e.target.value ? Number(e.target.value) : null)} className="w-14 px-2 py-1 border border-hay-400 rounded text-sm text-center focus:outline-none" />
+                      </td>
+                      <td className="px-2 py-1.5">
+                        <input type="number" value={editTime} onChange={(e) => setEditTime(e.target.value)} className="w-20 px-2 py-1 border border-hay-400 rounded text-sm text-center focus:outline-none" />
+                      </td>
+                      <td className="px-2 py-1.5">
+                        <div className="flex gap-1">
+                          <button onClick={() => saveEdit(p.duoId)} className="px-2 py-1 bg-pasture-600 text-white text-xs rounded hover:bg-pasture-700">✓</button>
+                          <button onClick={() => setEditingId(null)} className="px-2 py-1 bg-dust-300 text-rope-600 text-xs rounded hover:bg-dust-400">✕</button>
+                        </div>
+                      </td>
+                    </>
+                  ) : (
+                    <>
+                      <td className="px-3 py-2 text-center text-rope-500 text-xs">{p.calledCattle ?? '—'}</td>
+                      <td className="px-3 py-2 text-center font-semibold text-rope-700">{p.cattleCount}</td>
+                      <td className="px-3 py-2 text-center text-rope-600 text-xs">{formatTime(p.timeSeconds, p.isSAT)}</td>
+                      <td className="px-3 py-2 text-center">
+                        <button onClick={() => startEdit(p)} className="p-1.5 rounded text-rope-400 hover:text-saddle-600 hover:bg-dust-100 transition-colors">
+                          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" /></svg>
+                        </button>
+                      </td>
+                    </>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    );
   }
 
   return (
@@ -132,6 +200,7 @@ export default function Qualifiers() {
                           '#': idx + 1,
                           Dupla: p.duoLabel,
                           Grupo: p.group,
+                          'Boi Cantado': p.calledCattle ?? '',
                           Bois: p.cattleCount,
                           'Tempo (s)': p.timeSeconds,
                           SAT: p.isSAT ? 'Sim' : 'Não',
@@ -167,32 +236,30 @@ export default function Qualifiers() {
             {currentDuo ? (
               <Card title="Registrar resultado">
                 <div className="mb-4 p-3 rounded-lg bg-hay-50 border border-hay-200">
-                  <p className="text-xs text-hay-700 font-medium mb-0.5">Dupla atual</p>
-                  <p className="text-rope-800 font-semibold text-sm">
-                    {currentDuo.number}. {currentDuo.label}
-                  </p>
+                  <p className="text-xs text-hay-700 font-medium mb-0.5">Passada {currentDuo.number}</p>
+                  <p className="text-rope-800 font-semibold text-sm">{currentDuo.label}</p>
                   <GroupBadge group={currentDuo.group} size="sm" />
                 </div>
 
-                <div className="flex flex-col gap-3">
-                  <div>
-                    <label className="text-sm font-medium text-rope-700 block mb-1">
-                      Bois (0–10)
-                    </label>
-                    <input
-                      type="number"
-                      min={0}
-                      max={10}
-                      placeholder="0"
-                      value={form.cattleCount}
-                      onChange={(e) => { setForm({ ...form, cattleCount: e.target.value }); setFormErrors({}); }}
-                      className={[
-                        'w-full px-3 py-2 rounded-lg border text-sm focus:outline-none focus:ring-2 focus:ring-hay-400',
-                        formErrors.cattle ? 'border-brand-500' : 'border-dust-300',
-                      ].join(' ')}
-                    />
-                    {formErrors.cattle && <p className="text-xs text-brand-500 mt-0.5">{formErrors.cattle}</p>}
-                  </div>
+                <div className="flex flex-col gap-4">
+                  <QuickSelect
+                    label="Boi Cantado (0–9)"
+                    value={calledCattle}
+                    onChange={setCalledCattle}
+                    min={0}
+                    max={9}
+                    cols={5}
+                  />
+
+                  <QuickSelect
+                    label="Quantidade de Bois (0–10)"
+                    value={cattle}
+                    onChange={setCattle}
+                    min={0}
+                    max={10}
+                    cols={6}
+                  />
+
                   <div>
                     <label className="text-sm font-medium text-rope-700 block mb-1">
                       Tempo (segundos)
@@ -202,15 +269,16 @@ export default function Qualifiers() {
                       min={0.01}
                       step={0.01}
                       placeholder="45.5"
-                      value={form.timeSeconds}
-                      onChange={(e) => { setForm({ ...form, timeSeconds: e.target.value }); setFormErrors({}); }}
+                      value={timeSeconds}
+                      onChange={(e) => { setTimeSeconds(e.target.value); setTimeError(''); }}
                       className={[
                         'w-full px-3 py-2 rounded-lg border text-sm focus:outline-none focus:ring-2 focus:ring-hay-400',
-                        formErrors.time ? 'border-brand-500' : 'border-dust-300',
+                        timeError ? 'border-brand-500' : 'border-dust-300',
                       ].join(' ')}
                     />
-                    {formErrors.time && <p className="text-xs text-brand-500 mt-0.5">{formErrors.time}</p>}
+                    {timeError && <p className="text-xs text-brand-500 mt-0.5">{timeError}</p>}
                   </div>
+
                   <div className="flex gap-2">
                     <Button onClick={() => saveQualifierResult(false)} fullWidth>
                       Salvar
@@ -234,13 +302,12 @@ export default function Qualifiers() {
               </Card>
             )}
 
-            {/* Pending */}
             {pendingDuos.length > 0 && (
               <Card title={`Aguardando (${pendingDuos.length})`} noPadding>
                 <ul className="divide-y divide-dust-200 max-h-64 overflow-y-auto">
                   {pendingDuos.map((duo) => (
                     <li key={duo.id} className="px-4 py-2.5 flex items-center gap-2">
-                      <span className="text-rope-400 text-xs w-5">{duo.number}.</span>
+                      <span className="text-rope-400 text-xs w-6 font-mono">{duo.number}.</span>
                       <span className="text-rope-700 text-sm flex-1 truncate">{duo.label}</span>
                       <GroupBadge group={duo.group} />
                     </li>
@@ -261,70 +328,18 @@ export default function Qualifiers() {
             {partials.length === 0 ? (
               <EmptyState icon="📋" title="Sem resultados ainda" />
             ) : (
-              <div className="overflow-x-auto">
-                <table className="w-full text-sm">
-                  <thead className="bg-dust-50 border-b border-dust-200">
-                    <tr>
-                      <th className="px-4 py-2.5 text-left text-xs font-semibold text-rope-500 uppercase tracking-wide">#</th>
-                      <th className="px-4 py-2.5 text-left text-xs font-semibold text-rope-500 uppercase tracking-wide">Dupla</th>
-                      <th className="px-4 py-2.5 text-center text-xs font-semibold text-rope-500 uppercase tracking-wide">Grp</th>
-                      <th className="px-4 py-2.5 text-center text-xs font-semibold text-rope-500 uppercase tracking-wide">Bois</th>
-                      <th className="px-4 py-2.5 text-center text-xs font-semibold text-rope-500 uppercase tracking-wide">Tempo</th>
-                      <th className="px-4 py-2.5 text-center text-xs font-semibold text-rope-500 uppercase tracking-wide"></th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-dust-100">
-                    {partials.map((p, idx) => (
-                      <tr key={p.duoId} className="hover:bg-dust-50 transition-colors">
-                        <td className="px-4 py-2.5 text-rope-400 text-xs">{idx + 1}</td>
-                        <td className="px-4 py-2.5 font-medium text-rope-800 max-w-[160px] truncate">{p.duoLabel}</td>
-                        <td className="px-4 py-2.5 text-center"><GroupBadge group={p.group} /></td>
+              <div>
+                <RankingTable rows={partials1D} title={`Ranking 1D — Profissional (${partials1D.length})`} />
 
-                        {editingId === p.duoId ? (
-                          <>
-                            <td className="px-2 py-1.5">
-                              <input
-                                type="number"
-                                value={editForm.cattleCount}
-                                onChange={(e) => setEditForm({ ...editForm, cattleCount: e.target.value })}
-                                className="w-16 px-2 py-1 border border-hay-400 rounded text-sm focus:outline-none focus:ring-1 focus:ring-hay-400 text-center"
-                              />
-                            </td>
-                            <td className="px-2 py-1.5">
-                              <input
-                                type="number"
-                                value={editForm.timeSeconds}
-                                onChange={(e) => setEditForm({ ...editForm, timeSeconds: e.target.value })}
-                                className="w-20 px-2 py-1 border border-hay-400 rounded text-sm focus:outline-none focus:ring-1 focus:ring-hay-400 text-center"
-                              />
-                            </td>
-                            <td className="px-2 py-1.5">
-                              <div className="flex gap-1">
-                                <button onClick={() => saveEdit(p.duoId)} className="px-2 py-1 bg-pasture-600 text-white text-xs rounded hover:bg-pasture-700">✓</button>
-                                <button onClick={() => setEditingId(null)} className="px-2 py-1 bg-dust-300 text-rope-600 text-xs rounded hover:bg-dust-400">✕</button>
-                              </div>
-                            </td>
-                          </>
-                        ) : (
-                          <>
-                            <td className="px-4 py-2.5 text-center font-semibold text-rope-700">{p.cattleCount}</td>
-                            <td className="px-4 py-2.5 text-center text-rope-600">{formatTime(p.timeSeconds, p.isSAT)}</td>
-                            <td className="px-4 py-2.5 text-center">
-                              <button
-                                onClick={() => startEdit(p as any)}
-                                className="p-1.5 rounded text-rope-400 hover:text-saddle-600 hover:bg-dust-100 transition-colors"
-                              >
-                                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                                </svg>
-                              </button>
-                            </td>
-                          </>
-                        )}
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
+                {show2D ? (
+                  <RankingTable rows={partials2D} title={`Ranking 2D — Amador (${partials2D.length})`} />
+                ) : (
+                  <div className="px-4 py-3 border-t border-dust-200 bg-dust-50 text-center">
+                    <p className="text-xs text-rope-500">
+                      Ranking 2D disponível após {10 - partials1D.length} vaga{10 - partials1D.length !== 1 ? 's' : ''} do ranking 1D
+                    </p>
+                  </div>
+                )}
               </div>
             )}
           </Card>

--- a/src/screens/Registration/index.tsx
+++ b/src/screens/Registration/index.tsx
@@ -16,10 +16,8 @@ import { PageHeader } from '../../components/ui/PageHeader';
 import { UpgradeBadge, UpgradeModal } from '../../components/ui/UpgradePrompt';
 
 const CATEGORIES: { label: string; value: RiderCategory; hint: string }[] = [
-  { label: 'Aberta', value: 'Open', hint: 'Pode parear com qualquer categoria' },
-  { label: 'Amador', value: 'Amateur19', hint: 'Apenas com outros Amadores' },
-  { label: 'Amador Light', value: 'AmateurLight', hint: 'Com Light ou Principiante' },
-  { label: 'Principiante', value: 'Beginner', hint: 'Apenas com Principiantes' },
+  { label: 'Profissional', value: 'Open', hint: 'Grupo 1D' },
+  { label: 'Amador', value: 'AmateurLight', hint: 'Grupo 2D' },
 ];
 
 export default function Registration() {
@@ -34,13 +32,13 @@ export default function Registration() {
   const [upgradeOpen, setUpgradeOpen] = useState(false);
 
   const [name, setName] = useState('');
-  const [category, setCategory] = useState<RiderCategory>('Open');
+  const [category, setCategory] = useState<RiderCategory>('Open'); // 'Open' = Profissional
   const [nameError, setNameError] = useState('');
   const nameInputRef = useRef<HTMLInputElement>(null);
 
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editName, setEditName] = useState('');
-  const [editCategory, setEditCategory] = useState<RiderCategory>('Open');
+  const [editCategory, setEditCategory] = useState<RiderCategory>('Open'); // 'Open' = Profissional
 
   const [deleteTarget, setDeleteTarget] = useState<Competitor | null>(null);
   const [isSorting, setIsSorting] = useState(false);
@@ -106,7 +104,7 @@ export default function Registration() {
       const duosWithLabels = duos.map((duo) => {
         const riderOne = competitors.find((c) => c.id === duo.riderOneId);
         const riderTwo = competitors.find((c) => c.id === duo.riderTwoId);
-        const label = `${riderOne?.name ?? '?'} 🤝 ${riderTwo?.name ?? '?'}`;
+        const label = `${riderOne?.name ?? '?'} & ${riderTwo?.name ?? '?'}`;
         return { ...duo, label };
       });
 

--- a/src/screens/Registration/index.tsx
+++ b/src/screens/Registration/index.tsx
@@ -1,19 +1,26 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Competitor, RiderCategory } from 'core/models/Competidor';
 import { generateUniqueDuos } from 'core/logic/pairing';
 import { useResults } from 'context/ResultContext';
 import { useCompetition } from '../../context/CompetitionContext';
+import { useAuth } from '../../context/AuthContext';
 import { useToast } from '../../components/ui/Toast';
 import { useSubscription } from '../../hooks/useSubscription';
 import { Button } from '../../components/ui/Button';
 import { Input } from '../../components/ui/Input';
 import { CategoryBadge } from '../../components/ui/Badge';
 import { Card } from '../../components/ui/Card';
-import { ConfirmModal } from '../../components/ui/Modal';
+import { ConfirmModal, Modal } from '../../components/ui/Modal';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { PageHeader } from '../../components/ui/PageHeader';
 import { UpgradeBadge, UpgradeModal } from '../../components/ui/UpgradePrompt';
+import {
+  AthleteProfile,
+  listAthletes,
+  saveAthlete,
+  importProfilesAsCompetitors,
+} from '../../services/firebase/athletes';
 
 const CATEGORIES: { label: string; value: RiderCategory; hint: string }[] = [
   { label: 'Profissional', value: 'Open', hint: 'Grupo 1D' },
@@ -24,6 +31,7 @@ export default function Registration() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const toast = useToast();
+  const { user } = useAuth();
   const { isPro, limits } = useSubscription();
   const { setDuosMeta } = useResults();
   const { competitors, numRounds, setCompetitors, setDuos, setNumRounds } = useCompetition();
@@ -34,6 +42,7 @@ export default function Registration() {
   const [name, setName] = useState('');
   const [category, setCategory] = useState<RiderCategory>('Open'); // 'Open' = Profissional
   const [nameError, setNameError] = useState('');
+  const [saveToBase, setSaveToBase] = useState(false);
   const nameInputRef = useRef<HTMLInputElement>(null);
 
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -43,7 +52,23 @@ export default function Registration() {
   const [deleteTarget, setDeleteTarget] = useState<Competitor | null>(null);
   const [isSorting, setIsSorting] = useState(false);
 
-  function addCompetitor() {
+  // Base de atletas
+  const [athletePickerOpen, setAthletePickerOpen] = useState(false);
+  const [athletes, setAthletes] = useState<AthleteProfile[]>([]);
+  const [athleteSearch, setAthleteSearch] = useState('');
+  const [selectedAthleteIds, setSelectedAthleteIds] = useState<Set<string>>(new Set());
+  const [loadingAthletes, setLoadingAthletes] = useState(false);
+
+  useEffect(() => {
+    if (!athletePickerOpen || !user?.uid) return;
+    setLoadingAthletes(true);
+    listAthletes(user.uid)
+      .then(setAthletes)
+      .catch(() => toast('Erro ao carregar base de atletas', 'error'))
+      .finally(() => setLoadingAthletes(false));
+  }, [athletePickerOpen]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function addCompetitor() {
     if (!name.trim()) { setNameError('O nome é obrigatório'); return; }
     const newCompetitor: Competitor = {
       id: crypto.randomUUID(),
@@ -52,9 +77,19 @@ export default function Registration() {
       passes: numRounds,
     };
     setCompetitors([...competitors, newCompetitor]);
+
+    if (saveToBase && user?.uid) {
+      try {
+        await saveAthlete(user.uid, { name: newCompetitor.name, category: newCompetitor.category });
+      } catch {
+        toast('Competidor adicionado, mas falha ao salvar na base', 'warning');
+      }
+    }
+
     setName('');
     setNameError('');
     setCategory('Open');
+    setSaveToBase(false);
     nameInputRef.current?.focus();
     toast(`${newCompetitor.name} adicionado!`, 'success');
   }
@@ -124,6 +159,27 @@ export default function Registration() {
     }
   }
 
+  function handleImportAthletes() {
+    const selected = athletes.filter((a) => selectedAthleteIds.has(a.id));
+    const imported = importProfilesAsCompetitors(selected, numRounds);
+    // Deduplica por nome (case-insensitive)
+    const existingNames = new Set(competitors.map((c) => c.name.toLowerCase()));
+    const toAdd = imported.filter((c) => !existingNames.has(c.name.toLowerCase()));
+    if (toAdd.length === 0) {
+      toast('Todos os atletas selecionados já estão cadastrados.', 'info');
+    } else {
+      setCompetitors([...competitors, ...toAdd]);
+      toast(`${toAdd.length} atleta(s) importado(s)!`, 'success');
+    }
+    setAthletePickerOpen(false);
+    setSelectedAthleteIds(new Set());
+    setAthleteSearch('');
+  }
+
+  const filteredAthletes = athletes.filter((a) =>
+    a.name.toLowerCase().includes(athleteSearch.toLowerCase())
+  );
+
   const canSort = competitors.length >= 2;
 
   return (
@@ -171,7 +227,7 @@ export default function Registration() {
 
             <div>
               <p className="text-sm font-medium text-rope-700 mb-2">Categoria</p>
-              <div className="grid grid-cols-2 gap-2">
+              <div className="flex gap-2">
                 {CATEGORIES.map((cat) => (
                   <button
                     key={cat.value}
@@ -179,7 +235,7 @@ export default function Registration() {
                     onClick={() => setCategory(cat.value)}
                     title={cat.hint}
                     className={[
-                      'px-3 py-2 rounded-lg text-sm font-medium border transition-all text-left',
+                      'flex-1 px-3 py-2 rounded-lg text-sm font-medium border transition-all text-center',
                       category === cat.value
                         ? 'bg-saddle-600 text-white border-saddle-700 shadow-sm'
                         : 'bg-white text-rope-600 border-dust-300 hover:border-saddle-400',
@@ -190,6 +246,16 @@ export default function Registration() {
                 ))}
               </div>
             </div>
+
+            <label className="flex items-center gap-2 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={saveToBase}
+                onChange={(e) => setSaveToBase(e.target.checked)}
+                className="w-4 h-4 rounded border-dust-400 text-saddle-600 focus:ring-hay-400"
+              />
+              <span className="text-sm text-rope-600">Salvar na base de competidores</span>
+            </label>
 
             {atCompetitorLimit ? (
               <div className="flex flex-col gap-2">
@@ -208,6 +274,11 @@ export default function Registration() {
                 Adicionar Competidor
               </Button>
             )}
+
+            <Button variant="outline" size="sm" onClick={() => setAthletePickerOpen(true)} fullWidth>
+              Importar da Base
+            </Button>
+
             <UpgradeModal isOpen={upgradeOpen} onClose={() => setUpgradeOpen(false)} />
           </div>
         </Card>
@@ -227,7 +298,7 @@ export default function Registration() {
           ) : (
             <ul className="divide-y divide-dust-200">
               {competitors.map((c, index) => (
-                <li key={c.id} className="px-5 py-3">
+                <li key={c.id} className="px-4 py-3">
                   {editingId === c.id ? (
                     <div className="flex flex-col gap-3">
                       <input
@@ -237,14 +308,14 @@ export default function Registration() {
                         className="w-full px-3 py-1.5 rounded-lg border border-hay-400 focus:outline-none focus:ring-2 focus:ring-hay-400 text-sm"
                         autoFocus
                       />
-                      <div className="flex gap-2 flex-wrap">
+                      <div className="flex gap-2">
                         {CATEGORIES.map((cat) => (
                           <button
                             key={cat.value}
                             type="button"
                             onClick={() => setEditCategory(cat.value)}
                             className={[
-                              'px-2.5 py-1 rounded-md text-xs font-medium border transition-all',
+                              'flex-1 px-2.5 py-1 rounded-md text-xs font-medium border transition-all',
                               editCategory === cat.value
                                 ? 'bg-saddle-600 text-white border-saddle-700'
                                 : 'bg-white text-rope-500 border-dust-300 hover:border-saddle-400',
@@ -260,13 +331,22 @@ export default function Registration() {
                       </div>
                     </div>
                   ) : (
-                    <div className="flex items-center justify-between gap-3">
-                      <div className="flex items-center gap-2.5 min-w-0">
+                    <div className="flex items-center justify-between gap-2">
+                      <div className="flex items-center gap-2 min-w-0">
                         <span className="text-rope-400 text-xs w-5 text-right shrink-0">{index + 1}.</span>
                         <span className="font-medium text-rope-800 text-sm truncate">{c.name}</span>
                         <CategoryBadge category={c.category} />
                       </div>
                       <div className="flex gap-1 shrink-0">
+                        <button
+                          onClick={() => navigate(`/competition/${id}/competitor/${c.id}/history`)}
+                          className="p-1.5 rounded-md text-rope-400 hover:text-saddle-700 hover:bg-dust-100 transition-colors"
+                          title="Histórico"
+                        >
+                          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+                          </svg>
+                        </button>
                         <button
                           onClick={() => startEdit(c)}
                           className="p-1.5 rounded-md text-rope-400 hover:text-saddle-700 hover:bg-dust-100 transition-colors"
@@ -293,7 +373,7 @@ export default function Registration() {
             </ul>
           )}
           {canSort && (
-            <div className="px-5 py-3 border-t border-dust-200 bg-dust-50 rounded-b-xl">
+            <div className="px-4 py-3 border-t border-dust-200 bg-dust-50 rounded-b-xl">
               <Button onClick={handleSortDuos} loading={isSorting} fullWidth>
                 Sortear Duplas ({competitors.length} competidores, {numRounds} passada{numRounds !== 1 ? 's' : ''})
               </Button>
@@ -301,6 +381,61 @@ export default function Registration() {
           )}
         </Card>
       </div>
+
+      {/* Modal: Importar da Base */}
+      <Modal
+        isOpen={athletePickerOpen}
+        onClose={() => { setAthletePickerOpen(false); setSelectedAthleteIds(new Set()); setAthleteSearch(''); }}
+        title="Importar da Base de Atletas"
+        size="md"
+      >
+        <div className="flex flex-col gap-4">
+          <input
+            type="text"
+            placeholder="Buscar por nome..."
+            value={athleteSearch}
+            onChange={(e) => setAthleteSearch(e.target.value)}
+            className="w-full px-3 py-2 rounded-lg border border-dust-300 focus:outline-none focus:ring-2 focus:ring-hay-400 text-sm"
+            autoFocus
+          />
+          {loadingAthletes ? (
+            <p className="text-center text-rope-400 py-4">Carregando...</p>
+          ) : filteredAthletes.length === 0 ? (
+            <p className="text-center text-rope-400 py-4">
+              {athletes.length === 0 ? 'Nenhum atleta cadastrado na base.' : 'Nenhum atleta encontrado.'}
+            </p>
+          ) : (
+            <ul className="divide-y divide-dust-200 max-h-72 overflow-y-auto border border-dust-200 rounded-lg">
+              {filteredAthletes.map((a) => (
+                <li key={a.id}>
+                  <label className="flex items-center gap-3 px-4 py-2.5 cursor-pointer hover:bg-dust-50">
+                    <input
+                      type="checkbox"
+                      checked={selectedAthleteIds.has(a.id)}
+                      onChange={(e) => {
+                        const next = new Set(selectedAthleteIds);
+                        e.target.checked ? next.add(a.id) : next.delete(a.id);
+                        setSelectedAthleteIds(next);
+                      }}
+                      className="w-4 h-4 rounded border-dust-400 text-saddle-600 focus:ring-hay-400"
+                    />
+                    <span className="flex-1 text-sm text-rope-800">{a.name}</span>
+                    <CategoryBadge category={a.category} />
+                  </label>
+                </li>
+              ))}
+            </ul>
+          )}
+          <div className="flex justify-end gap-2 pt-1">
+            <Button variant="ghost" onClick={() => { setAthletePickerOpen(false); setSelectedAthleteIds(new Set()); setAthleteSearch(''); }}>
+              Cancelar
+            </Button>
+            <Button onClick={handleImportAthletes} disabled={selectedAthleteIds.size === 0}>
+              Adicionar {selectedAthleteIds.size > 0 ? `(${selectedAthleteIds.size})` : ''}
+            </Button>
+          </div>
+        </div>
+      </Modal>
 
       <ConfirmModal
         isOpen={!!deleteTarget}

--- a/src/services/firebase/athletes.ts
+++ b/src/services/firebase/athletes.ts
@@ -1,0 +1,66 @@
+import {
+  collection,
+  doc,
+  addDoc,
+  deleteDoc,
+  getDocs,
+  serverTimestamp,
+  Timestamp,
+} from 'firebase/firestore';
+import { db } from '../../firebase';
+import { RiderCategory } from '../../core/models/Competidor';
+import { Competitor } from '../../core/models/Competidor';
+
+export interface AthleteProfile {
+  id: string;
+  name: string;
+  category: RiderCategory;
+  createdAt: string;
+}
+
+function toAthleteProfile(id: string, data: any): AthleteProfile {
+  return {
+    id,
+    name: data.name,
+    category: data.category ?? 'Open',
+    createdAt:
+      data.createdAt instanceof Timestamp
+        ? data.createdAt.toDate().toISOString()
+        : data.createdAt ?? new Date().toISOString(),
+  };
+}
+
+export async function listAthletes(uid: string): Promise<AthleteProfile[]> {
+  const snap = await getDocs(collection(db, 'users', uid, 'athletes'));
+  return snap.docs
+    .map((d) => toAthleteProfile(d.id, d.data()))
+    .sort((a, b) => a.name.localeCompare(b.name, 'pt-BR'));
+}
+
+export async function saveAthlete(
+  uid: string,
+  profile: Omit<AthleteProfile, 'id' | 'createdAt'>
+): Promise<AthleteProfile> {
+  const ref = await addDoc(collection(db, 'users', uid, 'athletes'), {
+    name: profile.name,
+    category: profile.category,
+    createdAt: serverTimestamp(),
+  });
+  return { id: ref.id, ...profile, createdAt: new Date().toISOString() };
+}
+
+export async function deleteAthlete(uid: string, athleteId: string): Promise<void> {
+  await deleteDoc(doc(db, 'users', uid, 'athletes', athleteId));
+}
+
+export function importProfilesAsCompetitors(
+  profiles: AthleteProfile[],
+  passes: number
+): Competitor[] {
+  return profiles.map((p) => ({
+    id: crypto.randomUUID(),
+    name: p.name,
+    category: p.category,
+    passes,
+  }));
+}

--- a/src/services/firebase/competitions.ts
+++ b/src/services/firebase/competitions.ts
@@ -36,8 +36,27 @@ export interface Competition {
 
 type CompetitionPayload = Omit<Competition, 'id' | 'createdAt' | 'updatedAt'>;
 
+// Migrates legacy duo IDs that used '🤝' as separator to '_'
+function normalizeDuoIds(competition: Competition): Competition {
+  const remap = new Map<string, string>();
+  const duos = (competition.duos ?? []).map((d) => {
+    if (!d.id.includes('🤝')) return d;
+    const newId = d.id.replace(/🤝/g, '_');
+    remap.set(d.id, newId);
+    return { ...d, id: newId };
+  });
+  const fix = (id: string) => remap.get(id) ?? id;
+  const qualifierResults = (competition.qualifierResults ?? []).map((r) =>
+    remap.has(r.duoId) ? { ...r, duoId: fix(r.duoId) } : r
+  );
+  const finalResults = (competition.finalResults ?? []).map((r) =>
+    remap.has(r.duoId) ? { ...r, duoId: fix(r.duoId) } : r
+  );
+  return { ...competition, duos, qualifierResults, finalResults };
+}
+
 function toCompetition(id: string, data: any): Competition {
-  return {
+  const raw: Competition = {
     id,
     ownerId: data.ownerId,
     name: data.name,
@@ -58,6 +77,7 @@ function toCompetition(id: string, data: any): Competition {
     qualifierResults: data.qualifierResults ?? [],
     finalResults: data.finalResults ?? [],
   };
+  return normalizeDuoIds(raw);
 }
 
 export async function createCompetition(

--- a/src/utils/getDuoKey.ts
+++ b/src/utils/getDuoKey.ts
@@ -1,9 +1,7 @@
-// src/utils/getDuoKey.ts
 import { Competitor } from 'core/models/Competidor';
+import { duoKeyFromRiders } from 'core/models/Duo';
 
 export const getDuoKey = (duo: Competitor[]): string =>
-  duo.map((p: Competitor) => p.name).join('🤝');
+  duo.map((p: Competitor) => p.name).join(' & ');
 
-export function duoKeyFromRiders(riderAId: string, riderBId: string): string {
-  return [riderAId, riderBId].sort().join('🤝');
-}
+export { duoKeyFromRiders };

--- a/src/utils/importExcel.ts
+++ b/src/utils/importExcel.ts
@@ -2,9 +2,6 @@ import * as XLSX from 'xlsx';
 import { Duo } from 'core/models/Duo';
 import { Competitor } from 'core/index';
 
-/**
- * Importa duplas de um arquivo Excel e cria competidores ausentes automaticamente.
- */
 export async function importDuosFromExcel(
   file: File,
   competitors: Competitor[],
@@ -19,14 +16,15 @@ export async function importDuosFromExcel(
 
       const newCompetitors: Competitor[] = [];
       const importedDuos: Duo[] = rows.map((row) => {
-        const duoNames = String(row.Dupla || '')
-          .split('🤝')
-          .map((s) => s.trim());
+        const raw = String(row.Dupla || '');
+        // Aceita tanto " & " (novo) quanto " 🤝 " / "🤝" (legado)
+        const duoNames = raw.includes(' & ')
+          ? raw.split(' & ').map((s) => s.trim())
+          : raw.split('🤝').map((s) => s.trim());
         const riderOneName = duoNames[0];
         const riderTwoName = duoNames[1];
         const group = String(row.Categoria || '1D') as Duo['group'];
 
-        // Verifica se os competidores já existem
         let riderOne =
           competitors.find(
             (c) => c.name.toLowerCase() === riderOneName.toLowerCase()
@@ -43,7 +41,6 @@ export async function importDuosFromExcel(
             (c) => c.name.toLowerCase() === riderTwoName.toLowerCase()
           );
 
-        // Cria novos competidores se necessário
         if (!riderOne && riderOneName) {
           riderOne = {
             id: crypto.randomUUID(),
@@ -68,12 +65,11 @@ export async function importDuosFromExcel(
           id: crypto.randomUUID(),
           riderOneId: riderOne!.id,
           riderTwoId: riderTwo!.id,
-          label: `${riderOneName} 🤝 ${riderTwoName}`,
+          label: `${riderOneName} & ${riderTwoName}`,
           group,
         };
       });
 
-      // Atualiza competidores globais
       if (newCompetitors.length > 0) {
         setCompetitors((prev) => [...prev, ...newCompetitors]);
       }


### PR DESCRIPTION
$(cat <<'EOF'
## Resumo

Implementação completa das 9 fases de evolução do Ranch Sorting Pro, preservando a arquitetura React 19 + TypeScript + Firebase + Tailwind existente.

## Fases implementadas

### Fase 1 — Fundação
- Formato de dupla alterado de `"A 🤝 B"` para `"A & B"`
- Campo `passNumber` adicionado ao modelo `Duo`
- Campo `calledCattle` adicionado ao modelo `PassResult`
- Migração transparente de IDs legados do Firestore (separador `🤝` → `_`)
- Labels de categoria atualizados: `Open` → "Profissional", `AmateurLight` → "Amador"

### Fase 2 — Base Persistente de Atletas
- Perfis persistentes em `users/{uid}/athletes` (Firestore subcollection)
- Modal "Importar da Base" com busca por nome
- Checkbox "Salvar na base de competidores" ao adicionar
- UI simplificada para 2 categorias (Profissional / Amador)

### Fase 3 — Sorteio Revisado
- `passNumber` sequencial atribuído a cada dupla após sorteio
- Competidores em número ímpar com passadas ímpares recebem passada extra (com aviso)
- Export geral e por competidor na tela de Duplas

### Fase 4 — Boi Cantado + Botões Rápidos
- Componente `QuickSelect`: grid de botões para seleção rápida de números
- Campo "Boi Cantado" (0–9) e "Quantidade de Bois" (0–10) com QuickSelect nas telas de Qualificatória e Final
- Tela Final: aba 2D como padrão, aba 1D bloqueada até 2D ser concluída

### Fase 5 — Ranking 2D após 1D
- Ranking 2D exibido apenas após 10 vagas preenchidas no ranking 1D
- Banner informativo enquanto bloqueado

### Fase 6 — Ordem da Final
- Aba 2D como padrão na tela Final
- Aba 1D desabilitada com cadeado enquanto 2D não estiver completa

### Fase 7 — Histórico do Competidor
- Tela `/competition/:id/competitor/:competitorId/history`
- Passadas de qualificatórias e finais filtradas por competidor
- Estatísticas: média de bois, tempo médio, total de SATs
- Botão de acesso na lista de competidores (ícone de histórico)

### Fase 8 — Visão do Locutor
- Tela `/competition/:id/announcer`
- Funciona em ambas as etapas (qualificatória e final)
- Destaque da próxima dupla (número da passada + nome + grupo)
- Pré-anúncio da dupla seguinte
- Última passada registrada (bois, boi cantado, tempo)
- Estatísticas: total / concluídas / restantes
- Botão de tela cheia

### Fase 9 — Responsividade Mobile
- Nav da competição exibe apenas ícones em mobile (`< sm`), labels em `sm+`
- `PageHeader` com `flex-wrap` nas actions
- Coluna de dupla truncada no FinalResults em telas pequenas

## Test plan

- [ ] Criar competição → cadastrar competidores (Pro e Amador) → sortear duplas → verificar `passNumber` sequencial
- [ ] Competidores em número ímpar com passadas ímpares → verificar warning de passada extra
- [ ] Registrar resultados com Boi Cantado → verificar exibição no ranking e histórico
- [ ] Qualificatória: confirmar que ranking 2D aparece somente após 10 resultados 1D
- [ ] Final: confirmar que aba 1D fica bloqueada até 2D ser concluída
- [ ] Verificar tela do Locutor em etapa qualificatória e final
- [ ] Verificar histórico individual pelo ícone na tela de inscrições
- [ ] Testar em mobile (375px) — nav com ícones, PageHeader sem overflow

https://claude.ai/code/session_01EQ965jHXd8rDq9Qo7HFAjV
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EQ965jHXd8rDq9Qo7HFAjV)_