### PR TITLE
UX/UI: responsividade, categorias, exportação PNG e melhorias gerais

### DIFF
--- a/src/components/layout/CompetitionLayout.tsx
+++ b/src/components/layout/CompetitionLayout.tsx
@@ -91,24 +91,24 @@ export function CompetitionLayout() {
       </header>
 
       {/* Step Navigation */}
-      <nav className="bg-white border-b border-dust-300 px-2 sm:px-4 overflow-x-auto">
-        <div className="flex gap-0 max-w-5xl mx-auto">
+      <nav className="bg-white border-b border-dust-300 overflow-x-auto scrollbar-none">
+        <div className="flex gap-0 max-w-5xl mx-auto min-w-max px-1 sm:px-4">
           {steps.map((step) => (
             <NavLink
               key={step.key}
               to={`/competition/${id}/${step.key}`}
               className={({ isActive }) =>
                 [
-                  'flex items-center gap-1 sm:gap-1.5 px-2.5 sm:px-4 py-3 text-xs sm:text-sm font-medium whitespace-nowrap',
-                  'border-b-2 transition-colors',
+                  'flex flex-col sm:flex-row items-center gap-0.5 sm:gap-1.5 px-3 sm:px-4 py-2 sm:py-3',
+                  'text-xs font-medium whitespace-nowrap border-b-2 transition-colors',
                   isActive
                     ? 'border-saddle-600 text-saddle-700'
                     : 'border-transparent text-rope-400 hover:text-rope-700 hover:border-dust-400',
                 ].join(' ')
               }
             >
-              <span>{step.icon}</span>
-              <span className="hidden sm:inline">{step.label}</span>
+              <span className="text-base sm:text-sm">{step.icon}</span>
+              <span className="text-[10px] sm:text-sm leading-tight">{step.label}</span>
             </NavLink>
           ))}
         </div>

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -12,19 +12,11 @@ interface CategoryBadgeProps {
 const categoryConfig: Record<RiderCategory, { label: string; className: string }> = {
   Open: {
     label: 'Profissional',
-    className: 'bg-hay-200 text-rope-700 border border-hay-400',
-  },
-  Amateur19: {
-    label: 'Amador Avançado',
-    className: 'bg-pasture-100 text-pasture-800 border border-pasture-400',
+    className: 'bg-hay-100 text-rope-600 border border-hay-300',
   },
   AmateurLight: {
     label: 'Amador',
-    className: 'bg-saddle-100 text-saddle-700 border border-saddle-400',
-  },
-  Beginner: {
-    label: 'Iniciante',
-    className: 'bg-dust-200 text-rope-500 border border-dust-400',
+    className: 'bg-dust-100 text-rope-500 border border-dust-300',
   },
 };
 

--- a/src/core/models/Competidor.ts
+++ b/src/core/models/Competidor.ts
@@ -1,4 +1,10 @@
-export type RiderCategory = 'Open' | 'Amateur19' | 'AmateurLight' | 'Beginner'; // Principiante
+export type RiderCategory = 'Open' | 'AmateurLight';
+
+// Migrates legacy category values to the simplified 2-category model.
+export function normalizeCategory(cat: string): RiderCategory {
+  if (cat === 'AmateurLight' || cat === 'Beginner') return 'AmateurLight';
+  return 'Open'; // Open, Amateur19, or any unknown value → Open
+}
 
 export interface Competitor {
   id: string;

--- a/src/core/models/Duo.ts
+++ b/src/core/models/Duo.ts
@@ -16,41 +16,21 @@ export function duoKeyFromRiders(riderAId: string, riderBId: string): string {
 }
 
 /**
- * ASQM pairing compatibility rules.
- * Defines which categories can form a duo together.
- * Amateur19 can ONLY pair with Amateur19.
- * AmateurLight can pair with AmateurLight or Beginner.
- * Beginner can ONLY pair with Beginner.
- * Open can pair with anyone (result always counts as Aberta/1D class).
+ * Pairing compatibility rules.
+ * Open (Profissional/1D) can pair with anyone.
+ * AmateurLight (Amador/2D) can only pair with AmateurLight.
+ * Open + AmateurLight is valid (symmetric check) and results in 1D.
  */
 export const VALID_PAIRINGS: Record<RiderCategory, RiderCategory[]> = {
-  Open: ['Open', 'Amateur19', 'AmateurLight', 'Beginner'],
-  Amateur19: ['Amateur19'],
-  AmateurLight: ['AmateurLight', 'Beginner'],
-  Beginner: ['Beginner'],
+  Open: ['Open', 'AmateurLight'],
+  AmateurLight: ['AmateurLight'],
 };
 
 export function canPair(catA: RiderCategory, catB: RiderCategory): boolean {
-  // Symmetric: valid if either direction allows it
   return VALID_PAIRINGS[catA].includes(catB) || VALID_PAIRINGS[catB].includes(catA);
 }
 
-export function computeDuoGroup(
-  catA: RiderCategory,
-  catB: RiderCategory
-): DuoGroup {
-  // Any duo involving an Open competitor competes in the 1D (Aberta) class
+export function computeDuoGroup(catA: RiderCategory, catB: RiderCategory): DuoGroup {
   if (catA === 'Open' || catB === 'Open') return '1D';
-
-  // Amateur19+Amateur19 → 1D (their own Amador class, which is 1D-level)
-  if (catA === 'Amateur19' && catB === 'Amateur19') return '1D';
-
-  // AmateurLight+Amateur19 would be invalid per ASQM rules, but if it happens → 1D
-  if (catA === 'Amateur19' || catB === 'Amateur19') return '1D';
-
-  // AmateurLight pairs → 2D
-  if (catA === 'AmateurLight' || catB === 'AmateurLight') return '2D';
-
-  // Beginner+Beginner → 2D
   return '2D';
 }

--- a/src/screens/Announcer/index.tsx
+++ b/src/screens/Announcer/index.tsx
@@ -94,34 +94,34 @@ export default function Announcer() {
       </div>
 
       {/* Próxima e seguinte */}
-      <div className="grid gap-4 sm:grid-cols-2">
+      <div className="grid gap-3 sm:gap-4 sm:grid-cols-2">
         {/* Próxima dupla — destaque principal */}
-        <div className="rounded-2xl bg-saddle-800 text-white p-6 border border-saddle-700 shadow-lg">
+        <div className="rounded-2xl bg-saddle-800 text-white p-4 sm:p-6 border border-saddle-700 shadow-lg">
           <p className="text-saddle-300 text-xs uppercase tracking-widest mb-2">Próxima Passada</p>
           {currentDuo ? (
             <>
-              <p className="text-5xl font-bold font-serif text-hay-300 mb-2">
+              <p className="text-4xl sm:text-5xl font-bold font-serif text-hay-300 mb-2">
                 #{currentDuo.passNumber ?? '—'}
               </p>
-              <p className="text-2xl font-semibold leading-tight mb-3">{currentDuo.label}</p>
+              <p className="text-lg sm:text-2xl font-semibold leading-tight mb-3 break-words">{currentDuo.label}</p>
               <GroupBadge group={currentDuo.group} size="md" />
             </>
           ) : (
-            <p className="text-2xl text-saddle-300 font-semibold mt-2">
+            <p className="text-xl sm:text-2xl text-saddle-300 font-semibold mt-2">
               {total === 0 ? 'Sem duplas' : '✅ Etapa concluída!'}
             </p>
           )}
         </div>
 
         {/* Dupla seguinte — pré-anúncio */}
-        <div className="rounded-2xl bg-white p-6 border border-dust-300 shadow-sm">
+        <div className="rounded-2xl bg-white p-4 sm:p-6 border border-dust-300 shadow-sm">
           <p className="text-rope-400 text-xs uppercase tracking-widest mb-2">Em Seguida</p>
           {nextDuo ? (
             <>
-              <p className="text-3xl font-bold font-serif text-saddle-600 mb-2">
+              <p className="text-2xl sm:text-3xl font-bold font-serif text-saddle-600 mb-2">
                 #{nextDuo.passNumber ?? '—'}
               </p>
-              <p className="text-xl font-semibold text-rope-800 leading-tight mb-3">{nextDuo.label}</p>
+              <p className="text-base sm:text-xl font-semibold text-rope-800 leading-tight mb-3 break-words">{nextDuo.label}</p>
               <GroupBadge group={nextDuo.group} size="md" />
             </>
           ) : (
@@ -132,27 +132,27 @@ export default function Announcer() {
 
       {/* Última passada */}
       {lastResult && lastDuo && (
-        <div className="rounded-xl bg-white border border-dust-300 p-5">
+        <div className="rounded-xl bg-white border border-dust-300 p-4 sm:p-5">
           <p className="text-rope-400 text-xs uppercase tracking-widest mb-3">Última Passada</p>
-          <div className="flex flex-wrap items-center gap-4">
+          <div className="flex flex-wrap items-start gap-3 sm:gap-4">
             <div className="flex-1 min-w-0">
-              <p className="font-semibold text-rope-800 text-lg truncate">{lastDuo.label}</p>
+              <p className="font-semibold text-rope-800 text-base sm:text-lg break-words leading-snug">{lastDuo.label}</p>
               <GroupBadge group={lastDuo.group} />
             </div>
-            <div className="flex gap-6 text-center">
+            <div className="flex gap-4 sm:gap-6 text-center shrink-0">
               {lastResult.calledCattle !== undefined && (
                 <div>
-                  <p className="text-xs text-rope-400">Boi Cantado</p>
-                  <p className="text-2xl font-bold text-saddle-700">{lastResult.calledCattle}</p>
+                  <p className="text-xs text-rope-400">B. Cantado</p>
+                  <p className="text-xl sm:text-2xl font-bold text-saddle-700">{lastResult.calledCattle}</p>
                 </div>
               )}
               <div>
                 <p className="text-xs text-rope-400">Bois</p>
-                <p className="text-2xl font-bold text-rope-800">{lastResult.cattleCount}</p>
+                <p className="text-xl sm:text-2xl font-bold text-rope-800">{lastResult.cattleCount}</p>
               </div>
               <div>
                 <p className="text-xs text-rope-400">Tempo</p>
-                <p className="text-2xl font-bold text-rope-800">{formatTime(lastResult.timeSeconds, lastResult.isSAT)}</p>
+                <p className="text-xl sm:text-2xl font-bold text-rope-800">{formatTime(lastResult.timeSeconds, lastResult.isSAT)}</p>
               </div>
             </div>
           </div>
@@ -160,8 +160,8 @@ export default function Announcer() {
       )}
 
       {/* Estatísticas */}
-      <div className="grid grid-cols-3 gap-3">
-        <StatCard label="Total de Duplas" value={total} />
+      <div className="grid grid-cols-3 gap-2 sm:gap-3">
+        <StatCard label="Total" value={total} />
         <StatCard label="Concluídas" value={done} highlight />
         <StatCard label="Restantes" value={remaining} />
       </div>

--- a/src/screens/CompetitorHistory/index.tsx
+++ b/src/screens/CompetitorHistory/index.tsx
@@ -58,6 +58,15 @@ export default function CompetitorHistory() {
     return { sats, avgCattle, avgTime };
   }, [qualResults]);
 
+  // Estatísticas das finais
+  const finStats = useMemo(() => {
+    if (finResults.length === 0) return null;
+    const sats = finResults.filter((r) => r.isSAT).length;
+    const avgCattle = finResults.reduce((s, r) => s + r.cattleCount, 0) / finResults.length;
+    const avgTime = finResults.reduce((s, r) => s + r.timeSeconds, 0) / finResults.length;
+    return { sats, avgCattle, avgTime };
+  }, [finResults]);
+
   function formatTime(s: number, sat?: boolean) {
     return sat ? 'SAT' : `${s.toFixed(2)}s`;
   }
@@ -128,32 +137,41 @@ export default function CompetitorHistory() {
           {finResults.length === 0 ? (
             <EmptyState icon="🏆" title="Sem passadas na final" />
           ) : (
-            <div className="overflow-x-auto">
-              <table className="w-full text-sm">
-                <thead className="bg-dust-50 border-b border-dust-200">
-                  <tr>
-                    <th className="px-4 py-2.5 text-left text-xs font-semibold text-rope-500">Passada</th>
-                    <th className="px-4 py-2.5 text-left text-xs font-semibold text-rope-500">Parceiro</th>
-                    <th className="px-4 py-2.5 text-center text-xs font-semibold text-rope-500">Grp</th>
-                    <th className="px-4 py-2.5 text-center text-xs font-semibold text-rope-500">B.Cant.</th>
-                    <th className="px-4 py-2.5 text-center text-xs font-semibold text-rope-500">Bois</th>
-                    <th className="px-4 py-2.5 text-center text-xs font-semibold text-rope-500">Tempo</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-dust-100">
-                  {finResults.map((r) => (
-                    <tr key={r.id} className={r.isSAT ? 'bg-brand-50' : 'hover:bg-dust-50'}>
-                      <td className="px-4 py-2.5 text-rope-500 text-xs font-mono">#{getPassNumber(r.duoId)}</td>
-                      <td className="px-4 py-2.5 font-medium text-rope-800 text-sm">{getPartnerName(r.duoId)}</td>
-                      <td className="px-4 py-2.5 text-center"><GroupBadge group={getDuo(r.duoId)?.group ?? '1D'} /></td>
-                      <td className="px-4 py-2.5 text-center text-rope-500 text-sm">{r.calledCattle ?? '—'}</td>
-                      <td className="px-4 py-2.5 text-center font-semibold text-rope-700">{r.cattleCount}</td>
-                      <td className="px-4 py-2.5 text-center text-rope-600 text-sm">{formatTime(r.timeSeconds, r.isSAT)}</td>
+            <>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead className="bg-dust-50 border-b border-dust-200">
+                    <tr>
+                      <th className="px-4 py-2.5 text-left text-xs font-semibold text-rope-500">Passada</th>
+                      <th className="px-4 py-2.5 text-left text-xs font-semibold text-rope-500">Parceiro</th>
+                      <th className="px-4 py-2.5 text-center text-xs font-semibold text-rope-500">Grp</th>
+                      <th className="px-4 py-2.5 text-center text-xs font-semibold text-rope-500">B.Cant.</th>
+                      <th className="px-4 py-2.5 text-center text-xs font-semibold text-rope-500">Bois</th>
+                      <th className="px-4 py-2.5 text-center text-xs font-semibold text-rope-500">Tempo</th>
                     </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+                  </thead>
+                  <tbody className="divide-y divide-dust-100">
+                    {finResults.map((r) => (
+                      <tr key={r.id} className={r.isSAT ? 'bg-brand-50' : 'hover:bg-dust-50'}>
+                        <td className="px-4 py-2.5 text-rope-500 text-xs font-mono">#{getPassNumber(r.duoId)}</td>
+                        <td className="px-4 py-2.5 font-medium text-rope-800 text-sm">{getPartnerName(r.duoId)}</td>
+                        <td className="px-4 py-2.5 text-center"><GroupBadge group={getDuo(r.duoId)?.group ?? '1D'} /></td>
+                        <td className="px-4 py-2.5 text-center text-rope-500 text-sm">{r.calledCattle ?? '—'}</td>
+                        <td className="px-4 py-2.5 text-center font-semibold text-rope-700">{r.cattleCount}</td>
+                        <td className="px-4 py-2.5 text-center text-rope-600 text-sm">{formatTime(r.timeSeconds, r.isSAT)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              {finStats && (
+                <div className="px-4 py-3 bg-dust-50 border-t border-dust-200 flex flex-wrap gap-4 text-xs text-rope-600">
+                  <span>Média bois: <strong className="text-rope-800">{finStats.avgCattle.toFixed(2)}</strong></span>
+                  <span>Tempo médio: <strong className="text-rope-800">{formatTime(finStats.avgTime)}</strong></span>
+                  <span>SATs: <strong className="text-brand-600">{finStats.sats}</strong></span>
+                </div>
+              )}
+            </>
           )}
         </Card>
       </div>

--- a/src/screens/Duos/index.tsx
+++ b/src/screens/Duos/index.tsx
@@ -1,16 +1,20 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useResults } from 'context/ResultContext';
 import { useCompetition } from '../../context/CompetitionContext';
 import { useToast } from '../../components/ui/Toast';
 import { useSubscription } from '../../hooks/useSubscription';
 import { exportToExcel } from 'utils/exportExcel';
+import { exportDuosToPng } from 'utils/exportPng';
 import { importDuosFromExcel } from 'utils/importExcel';
 import { Button } from '../../components/ui/Button';
 import { Card } from '../../components/ui/Card';
-import { GroupBadge, CategoryBadge } from '../../components/ui/Badge';
+import { GroupBadge } from '../../components/ui/Badge';
 import { EmptyState } from '../../components/ui/EmptyState';
 import { PageHeader } from '../../components/ui/PageHeader';
+import { Modal } from '../../components/ui/Modal';
+import { UpgradeModal } from '../../components/ui/UpgradePrompt';
+import { Competitor } from '../../core/models/Competidor';
 
 export default function Duos() {
   const { id } = useParams<{ id: string }>();
@@ -20,16 +24,22 @@ export default function Duos() {
   const { setDuosMeta } = useResults();
   const { competitors, duos, setDuos, setCompetitors: setCompetitorsCtx } = useCompetition();
 
-  const setCompetitors: React.Dispatch<React.SetStateAction<typeof competitors>> = (
-    value
-  ) => {
+  const setCompetitors: React.Dispatch<React.SetStateAction<typeof competitors>> = (value) => {
     const next = typeof value === 'function' ? value(competitors) : value;
     setCompetitorsCtx(next);
   };
   const fileRef = useRef<HTMLInputElement>(null);
 
+  const [competitorPickerOpen, setCompetitorPickerOpen] = useState(false);
+  const [upgradeOpen, setUpgradeOpen] = useState(false);
+  const [competitorSearch, setCompetitorSearch] = useState('');
+
   const duos1D = duos.filter((d) => d.group === '1D');
   const duos2D = duos.filter((d) => d.group === '2D');
+
+  const filteredCompetitors = competitors.filter((c) =>
+    c.name.toLowerCase().includes(competitorSearch.toLowerCase())
+  );
 
   async function handleImport(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
@@ -45,7 +55,7 @@ export default function Duos() {
     }
   }
 
-  function handleExportGeral() {
+  function handleExportGeralExcel() {
     exportToExcel(
       duos.map((duo, idx) => {
         const a = competitors.find((c) => c.id === duo.riderOneId);
@@ -54,35 +64,73 @@ export default function Duos() {
           'Nº Passada': duo.passNumber ?? idx + 1,
           Dupla: `${a?.name ?? '?'} & ${b?.name ?? '?'}`,
           Categoria: duo.group,
-          'Cat. A': a?.category ?? '',
-          'Cat. B': b?.category ?? '',
         };
       }),
       'Duplas_Sorteio'
     );
   }
 
-  function handleExportPorCompetidor() {
-    const rows: { Competidor: string; 'Nº Passada': number; Dupla: string; Categoria: string }[] = [];
+  function handleExportGeralPng() {
+    exportDuosToPng({
+      title: 'Lista de Duplas',
+      subtitle: `${duos.length} duplas · ${duos1D.length} na 1D · ${duos2D.length} na 2D`,
+      rows: duos.map((duo, idx) => {
+        const a = competitors.find((c) => c.id === duo.riderOneId);
+        const b = competitors.find((c) => c.id === duo.riderTwoId);
+        return {
+          passNumber: duo.passNumber ?? idx + 1,
+          label: `${a?.name ?? '?'} & ${b?.name ?? '?'}`,
+          group: duo.group,
+        };
+      }),
+      fileName: 'Duplas_Sorteio',
+    });
+  }
 
-    for (const comp of competitors) {
-      const myDuos = duos.filter(
-        (d) => d.riderOneId === comp.id || d.riderTwoId === comp.id
+  function handleExportCompetidor(comp: Competitor) {
+    const myDuos = duos.filter((d) => d.riderOneId === comp.id || d.riderTwoId === comp.id);
+    const rows = myDuos.map((duo) => {
+      const partner = competitors.find(
+        (c) => c.id === (duo.riderOneId === comp.id ? duo.riderTwoId : duo.riderOneId)
       );
-      for (const duo of myDuos) {
+      return {
+        'Nº Passada': duo.passNumber ?? 0,
+        Dupla: duo.label ?? `${comp.name} & ${partner?.name ?? '?'}`,
+        Categoria: duo.group,
+      };
+    });
+    rows.sort((a, b) => a['Nº Passada'] - b['Nº Passada']);
+    return rows;
+  }
+
+  function exportCompetidorExcel(comp: Competitor) {
+    const rows = handleExportCompetidor(comp);
+    exportToExcel(rows, `Duplas_${comp.name.replace(/\s+/g, '_')}`);
+    setCompetitorPickerOpen(false);
+    setCompetitorSearch('');
+  }
+
+  function exportCompetidorPng(comp: Competitor) {
+    const myDuos = duos
+      .filter((d) => d.riderOneId === comp.id || d.riderTwoId === comp.id)
+      .sort((a, b) => (a.passNumber ?? 0) - (b.passNumber ?? 0));
+    exportDuosToPng({
+      title: comp.name,
+      subtitle: `${myDuos.length} passada${myDuos.length !== 1 ? 's' : ''} no sorteio`,
+      rows: myDuos.map((duo) => {
         const partner = competitors.find(
           (c) => c.id === (duo.riderOneId === comp.id ? duo.riderTwoId : duo.riderOneId)
         );
-        rows.push({
-          Competidor: comp.name,
-          'Nº Passada': duo.passNumber ?? 0,
-          Dupla: duo.label ?? `${comp.name} & ${partner?.name ?? '?'}`,
-          Categoria: duo.group,
-        });
-      }
-    }
-    rows.sort((a, b) => a.Competidor.localeCompare(b.Competidor, 'pt-BR') || a['Nº Passada'] - b['Nº Passada']);
-    exportToExcel(rows, 'Duplas_Por_Competidor');
+        return {
+          passNumber: duo.passNumber ?? 0,
+          label: `${comp.name} & ${partner?.name ?? '?'}`,
+          group: duo.group,
+        };
+      }),
+      fileName: `Duplas_${comp.name.replace(/\s+/g, '_')}`,
+    });
+    setCompetitorPickerOpen(false);
+    setCompetitorSearch('');
   }
 
   function DuoList({ items }: { items: typeof duos }) {
@@ -98,13 +146,9 @@ export default function Duos() {
                 {passNum}.
               </span>
               <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-1.5 flex-wrap">
-                  <span className="font-medium text-rope-800 text-sm">{a?.name ?? '?'}</span>
-                  {a && <CategoryBadge category={a.category} />}
-                  <span className="text-rope-400 text-sm font-bold">&amp;</span>
-                  <span className="font-medium text-rope-800 text-sm">{b?.name ?? '?'}</span>
-                  {b && <CategoryBadge category={b.category} />}
-                </div>
+                <span className="font-medium text-rope-800 text-sm truncate block">
+                  {a?.name ?? '?'} &amp; {b?.name ?? '?'}
+                </span>
               </div>
               <GroupBadge group={duo.group} />
             </li>
@@ -121,13 +165,16 @@ export default function Duos() {
         subtitle={`${duos.length} dupla${duos.length !== 1 ? 's' : ''} sorteada${duos.length !== 1 ? 's' : ''} · ${duos1D.length} na 1D · ${duos2D.length} na 2D`}
         actions={
           <div className="flex flex-wrap gap-2">
-            <Button variant="outline" size="sm" onClick={handleExportGeral} disabled={duos.length === 0}>
-              Exportar Lista
+            <Button variant="outline" size="sm" onClick={handleExportGeralExcel} disabled={duos.length === 0}>
+              Planilha
+            </Button>
+            <Button variant="outline" size="sm" onClick={handleExportGeralPng} disabled={duos.length === 0}>
+              PNG
             </Button>
             <Button
               variant="outline"
               size="sm"
-              onClick={isPro ? handleExportPorCompetidor : undefined}
+              onClick={isPro ? () => setCompetitorPickerOpen(true) : () => setUpgradeOpen(true)}
               disabled={duos.length === 0}
               title={isPro ? 'Exportar por competidor' : 'Disponível no plano Pro'}
             >
@@ -178,6 +225,67 @@ export default function Duos() {
           </div>
         </div>
       )}
+
+      {/* Modal: selecionar competidor para exportar */}
+      <Modal
+        isOpen={competitorPickerOpen}
+        onClose={() => { setCompetitorPickerOpen(false); setCompetitorSearch(''); }}
+        title="Exportar por Competidor"
+        size="md"
+      >
+        <div className="flex flex-col gap-4">
+          <input
+            type="text"
+            placeholder="Buscar competidor..."
+            value={competitorSearch}
+            onChange={(e) => setCompetitorSearch(e.target.value)}
+            className="w-full px-3 py-2 rounded-lg border border-dust-300 focus:outline-none focus:ring-2 focus:ring-hay-400 text-sm"
+            autoFocus
+          />
+          {filteredCompetitors.length === 0 ? (
+            <p className="text-center text-rope-400 py-4 text-sm">Nenhum competidor encontrado.</p>
+          ) : (
+            <ul className="divide-y divide-dust-200 border border-dust-200 rounded-lg max-h-72 overflow-y-auto">
+              {filteredCompetitors.map((comp) => {
+                const count = duos.filter((d) => d.riderOneId === comp.id || d.riderTwoId === comp.id).length;
+                return (
+                  <li key={comp.id} className="px-4 py-3 hover:bg-dust-50">
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="font-medium text-rope-800 text-sm truncate">{comp.name}</p>
+                        <p className="text-xs text-rope-400">{count} passada{count !== 1 ? 's' : ''}</p>
+                      </div>
+                      <div className="flex gap-1.5 shrink-0">
+                        <button
+                          type="button"
+                          onClick={() => exportCompetidorExcel(comp)}
+                          className="px-2.5 py-1 text-xs rounded-md border border-dust-300 text-rope-600 hover:border-saddle-400 hover:text-saddle-700 transition-colors"
+                        >
+                          Planilha
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => exportCompetidorPng(comp)}
+                          className="px-2.5 py-1 text-xs rounded-md border border-dust-300 text-rope-600 hover:border-saddle-400 hover:text-saddle-700 transition-colors"
+                        >
+                          PNG
+                        </button>
+                      </div>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+          <div className="flex justify-end pt-1">
+            <Button variant="ghost" onClick={() => { setCompetitorPickerOpen(false); setCompetitorSearch(''); }}>
+              Fechar
+            </Button>
+          </div>
+        </div>
+      </Modal>
+
+      <UpgradeModal isOpen={upgradeOpen} onClose={() => setUpgradeOpen(false)} />
     </div>
   );
 }

--- a/src/screens/Final/index.tsx
+++ b/src/screens/Final/index.tsx
@@ -6,6 +6,7 @@ import { useSubscription } from '../../hooks/useSubscription';
 import { PassResult } from 'core/models/PassResult';
 import { Duo, DuoGroup } from 'core/models/Duo';
 import { exportToExcel } from 'utils/exportExcel';
+import { exportResultsToPng } from 'utils/exportPng';
 import { Button } from '../../components/ui/Button';
 import { Card } from '../../components/ui/Card';
 import { GroupBadge } from '../../components/ui/Badge';
@@ -137,6 +138,48 @@ export default function Finals() {
 
   const partialsFiltered = partials.filter((p) => p?.group === activeTab);
 
+  const FINAL_COLUMNS = [
+    { header: '#', width: 36, align: 'center' as const },
+    { header: 'DUPLA', width: 170, align: 'left' as const },
+    { header: 'GRP', width: 44, align: 'center' as const },
+    { header: 'B.C', width: 44, align: 'center' as const },
+    { header: 'Q.BOIS', width: 52, align: 'center' as const },
+    { header: 'Q.TEMPO', width: 64, align: 'center' as const },
+    { header: 'F.BOIS', width: 52, align: 'center' as const },
+    { header: 'F.TEMPO', width: 64, align: 'center' as const },
+    { header: 'MÉD.B', width: 52, align: 'center' as const },
+    { header: 'MÉD.T', width: 64, align: 'center' as const },
+  ];
+
+  function handleExportFinalPng() {
+    const sorted = [...partialsFiltered].sort(
+      (a, b) => (b?.avgCattle ?? 0) - (a?.avgCattle ?? 0) || (a?.avgTime ?? 0) - (b?.avgTime ?? 0)
+    );
+    const rows = sorted.map((p, idx) => ({
+      cells: [
+        idx === 0 ? '🥇' : idx === 1 ? '🥈' : idx === 2 ? '🥉' : String(idx + 1),
+        p?.label ?? '',
+        p?.group ?? '',
+        p?.calledCattle != null ? String(p.calledCattle) : '—',
+        String(p?.qualiCattle ?? ''),
+        formatTime(p?.qualiTime ?? 0),
+        String(p?.finalCattle ?? ''),
+        formatTime(p?.finalTime ?? 0),
+        (p?.avgCattle ?? 0).toFixed(1),
+        formatTime(p?.avgTime ?? 0),
+      ],
+      highlight: idx < 3,
+      isSAT: (p?.finalTime ?? 0) >= 120,
+    }));
+    exportResultsToPng({
+      title: `Final ${activeTab} — Parciais`,
+      subtitle: `${partialsFiltered.length} duplas · ${activeTab === '1D' ? 'Profissional' : 'Amador'}`,
+      columns: FINAL_COLUMNS,
+      rows,
+      fileName: `Resultados_Final_${activeTab}`,
+    });
+  }
+
   return (
     <div>
       <PageHeader
@@ -171,7 +214,15 @@ export default function Finals() {
               }
               disabled={partialsFiltered.length === 0}
             >
-              Exportar {activeTab}
+              Planilha {activeTab}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={isPro ? handleExportFinalPng : () => setUpgradeOpen(true)}
+              disabled={partialsFiltered.length === 0}
+            >
+              PNG {activeTab}
             </Button>
             <UpgradeModal isOpen={upgradeOpen} onClose={() => setUpgradeOpen(false)} />
           </div>

--- a/src/screens/Final/index.tsx
+++ b/src/screens/Final/index.tsx
@@ -207,9 +207,9 @@ export default function Finals() {
         })}
       </div>
 
-      <div className="grid gap-5 lg:grid-cols-5">
+      <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-5">
         {/* Entry form */}
-        <div className="lg:col-span-2 flex flex-col gap-4">
+        <div className="md:col-span-1 lg:col-span-2 flex flex-col gap-4">
           {currentDuo ? (
             <Card title={`Registrar resultado — ${activeTab}`}>
               <div className="mb-4 p-3 rounded-lg bg-hay-50 border border-hay-200">
@@ -225,7 +225,7 @@ export default function Finals() {
 
               <div className="flex flex-col gap-4">
                 <QuickSelect
-                  label="Boi Cantado (0–9)"
+                  label="Boi Cantado"
                   value={currentForm.calledCattle}
                   onChange={(v) => setFormField('calledCattle', v)}
                   min={0}
@@ -234,7 +234,7 @@ export default function Finals() {
                 />
 
                 <QuickSelect
-                  label="Quantidade de Bois (0–10)"
+                  label="Quantidade de Bois"
                   value={currentForm.cattle}
                   onChange={(v) => setFormField('cattle', v)}
                   min={0}
@@ -295,7 +295,7 @@ export default function Finals() {
         </div>
 
         {/* Results table */}
-        <Card className="lg:col-span-3" title={`Parciais ${activeTab} (${partialsFiltered.length})`} noPadding>
+        <Card className="md:col-span-1 lg:col-span-3" title={`Parciais ${activeTab} (${partialsFiltered.length})`} noPadding>
           {partialsFiltered.length === 0 ? (
             <EmptyState icon="🏆" title="Sem resultados ainda" />
           ) : (

--- a/src/screens/Qualifiers/index.tsx
+++ b/src/screens/Qualifiers/index.tsx
@@ -15,6 +15,7 @@ import { EmptyState } from '../../components/ui/EmptyState';
 import { PageHeader } from '../../components/ui/PageHeader';
 import { UpgradeBadge, UpgradeModal } from '../../components/ui/UpgradePrompt';
 import { QuickSelect } from '../../components/ui/QuickSelect';
+import { Modal } from '../../components/ui/Modal';
 
 type PartialRow = DuoScore & { duoLabel: string; isSAT?: boolean; calledCattle?: number };
 
@@ -37,6 +38,9 @@ export default function Qualifiers() {
   const [editCalledCattle, setEditCalledCattle] = useState<number | null>(null);
   const [editTime, setEditTime] = useState('');
 
+  const [selectDuoOpen, setSelectDuoOpen] = useState(false);
+  const [overrideDuoId, setOverrideDuoId] = useState<string | null>(null);
+
   const metaDuos = duosMeta.length > 0 ? duosMeta : compDuos;
   const duos = metaDuos.map((d, index) => ({ ...d, number: d.passNumber ?? index + 1 }));
 
@@ -45,7 +49,9 @@ export default function Qualifiers() {
   );
 
   const pendingDuos = duos.filter((d) => !registeredDuoIds.has(d.id));
-  const currentDuo = pendingDuos[0] ?? null;
+  const currentDuo = overrideDuoId
+    ? (pendingDuos.find((d) => d.id === overrideDuoId) ?? pendingDuos[0] ?? null)
+    : (pendingDuos[0] ?? null);
 
   const partials: PartialRow[] = results
     .filter((r: PassResult) => r.stage === 'Qualifier')
@@ -94,6 +100,7 @@ export default function Qualifiers() {
     setCalledCattle(null);
     setTimeSeconds('');
     setTimeError('');
+    setOverrideDuoId(null);
     toast(isSAT ? `SAT registrado para ${currentDuo.label}` : 'Resultado salvo!', 'success');
   }
 
@@ -230,20 +237,31 @@ export default function Qualifiers() {
           }
         />
       ) : (
-        <div className="grid gap-5 lg:grid-cols-5">
+        <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-5">
           {/* Entry form */}
-          <div className="lg:col-span-2 flex flex-col gap-4">
+          <div className="md:col-span-1 lg:col-span-2 flex flex-col gap-4">
             {currentDuo ? (
               <Card title="Registrar resultado">
                 <div className="mb-4 p-3 rounded-lg bg-hay-50 border border-hay-200">
                   <p className="text-xs text-hay-700 font-medium mb-0.5">Passada {currentDuo.number}</p>
                   <p className="text-rope-800 font-semibold text-sm">{currentDuo.label}</p>
-                  <GroupBadge group={currentDuo.group} size="sm" />
+                  <div className="flex items-center justify-between gap-2 mt-1">
+                    <GroupBadge group={currentDuo.group} size="sm" />
+                    {pendingDuos.length > 1 && (
+                      <button
+                        type="button"
+                        onClick={() => setSelectDuoOpen(true)}
+                        className="text-xs text-rope-400 hover:text-saddle-600 underline underline-offset-2 transition-colors"
+                      >
+                        Escolher outra dupla
+                      </button>
+                    )}
+                  </div>
                 </div>
 
                 <div className="flex flex-col gap-4">
                   <QuickSelect
-                    label="Boi Cantado (0–9)"
+                    label="Boi Cantado"
                     value={calledCattle}
                     onChange={setCalledCattle}
                     min={0}
@@ -252,7 +270,7 @@ export default function Qualifiers() {
                   />
 
                   <QuickSelect
-                    label="Quantidade de Bois (0–10)"
+                    label="Quantidade de Bois"
                     value={cattle}
                     onChange={setCattle}
                     min={0}
@@ -323,8 +341,45 @@ export default function Qualifiers() {
             )}
           </div>
 
+          {/* Modal: seleção manual de dupla */}
+          <Modal
+            isOpen={selectDuoOpen}
+            onClose={() => setSelectDuoOpen(false)}
+            title="Escolher dupla"
+            size="sm"
+          >
+            <div className="flex flex-col gap-2">
+              <p className="text-xs text-rope-400 mb-2">Selecione uma dupla pendente para registrar agora.</p>
+              <ul className="divide-y divide-dust-200 border border-dust-200 rounded-lg max-h-72 overflow-y-auto">
+                {pendingDuos.map((duo) => (
+                  <li key={duo.id}>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setOverrideDuoId(duo.id);
+                        setCattle(null);
+                        setCalledCattle(null);
+                        setTimeSeconds('');
+                        setTimeError('');
+                        setSelectDuoOpen(false);
+                      }}
+                      className={[
+                        'w-full flex items-center gap-3 px-4 py-2.5 hover:bg-dust-50 text-left transition-colors',
+                        overrideDuoId === duo.id ? 'bg-hay-50' : '',
+                      ].join(' ')}
+                    >
+                      <span className="text-rope-400 text-xs font-mono w-6 shrink-0">{duo.number}.</span>
+                      <span className="flex-1 text-sm text-rope-800 truncate">{duo.label}</span>
+                      <GroupBadge group={duo.group} />
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </Modal>
+
           {/* Results table */}
-          <Card className="lg:col-span-3" title={`Parciais (${partials.length})`} noPadding>
+          <Card className="md:col-span-1 lg:col-span-3" title={`Parciais (${partials.length})`} noPadding>
             {partials.length === 0 ? (
               <EmptyState icon="📋" title="Sem resultados ainda" />
             ) : (

--- a/src/screens/Qualifiers/index.tsx
+++ b/src/screens/Qualifiers/index.tsx
@@ -8,6 +8,7 @@ import { PassResult, DuoScore } from 'core/models/PassResult';
 import { DuoGroup } from 'core/models/Duo';
 import { compareByScore } from 'core/logic/scoring';
 import { exportToExcel } from 'utils/exportExcel';
+import { exportResultsToPng } from 'utils/exportPng';
 import { Button } from '../../components/ui/Button';
 import { Card } from '../../components/ui/Card';
 import { GroupBadge } from '../../components/ui/Badge';
@@ -126,6 +127,52 @@ export default function Qualifiers() {
     return sat ? 'SAT' : `${s.toFixed(2)}s`;
   }
 
+  const QUAL_COLUMNS = [
+    { header: '#', width: 36, align: 'center' as const },
+    { header: 'DUPLA', width: 200, align: 'left' as const },
+    { header: 'GRP', width: 44, align: 'center' as const },
+    { header: 'B.CANT', width: 56, align: 'center' as const },
+    { header: 'BOIS', width: 44, align: 'center' as const },
+    { header: 'TEMPO', width: 68, align: 'center' as const },
+  ];
+
+  function buildQualifierRows(rows: PartialRow[], startPos = 1) {
+    return rows.map((p, idx) => ({
+      cells: [
+        String(startPos + idx),
+        p.duoLabel,
+        p.group,
+        p.calledCattle != null ? String(p.calledCattle) : '—',
+        String(p.cattleCount),
+        formatTime(p.timeSeconds, p.isSAT),
+      ],
+      highlight: idx === 0,
+      isSAT: p.isSAT,
+    }));
+  }
+
+  function handleExportPng() {
+    const rows1D = buildQualifierRows(partials1D);
+    const rows2D = buildQualifierRows(partials2D);
+    const combinedRows = [
+      { cells: [`Ranking 1D — Profissional (${partials1D.length})`], isGroupHeader: true },
+      ...rows1D,
+      ...(show2D
+        ? [
+            { cells: [`Ranking 2D — Amador (${partials2D.length})`], isGroupHeader: true },
+            ...rows2D,
+          ]
+        : []),
+    ];
+    exportResultsToPng({
+      title: 'Classificatória — Parciais',
+      subtitle: `${partials.length} passadas registradas`,
+      columns: QUAL_COLUMNS,
+      rows: combinedRows,
+      fileName: 'Resultados_Qualificatorias',
+    });
+  }
+
   function RankingTable({ rows, title }: { rows: PartialRow[]; title: string }) {
     return (
       <div>
@@ -194,7 +241,7 @@ export default function Qualifiers() {
         title="Qualificatória"
         subtitle={`${registeredDuoIds.size} de ${duos.length} duplas registradas`}
         actions={
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 flex-wrap">
             {!isPro && <UpgradeBadge />}
             <Button
               variant="outline"
@@ -218,7 +265,15 @@ export default function Qualifiers() {
               }
               disabled={partials.length === 0}
             >
-              Exportar Excel
+              Planilha
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={isPro ? handleExportPng : () => setUpgradeOpen(true)}
+              disabled={partials.length === 0}
+            >
+              PNG
             </Button>
             <UpgradeModal isOpen={upgradeOpen} onClose={() => setUpgradeOpen(false)} />
           </div>

--- a/src/screens/Registration/index.tsx
+++ b/src/screens/Registration/index.tsx
@@ -196,9 +196,9 @@ export default function Registration() {
         }
       />
 
-      <div className="grid gap-5 lg:grid-cols-5">
+      <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-5">
         {/* Form */}
-        <Card className="lg:col-span-2" title="Adicionar competidor">
+        <Card className="md:col-span-1 lg:col-span-2" title="Adicionar competidor">
           <div className="flex flex-col gap-4">
             <div>
               <label className="text-sm font-medium text-rope-700 block mb-1">
@@ -285,7 +285,7 @@ export default function Registration() {
 
         {/* List */}
         <Card
-          className="lg:col-span-3"
+          className="md:col-span-1 lg:col-span-3"
           title={`Competidores (${competitors.length})`}
           noPadding
         >

--- a/src/services/firebase/athletes.ts
+++ b/src/services/firebase/athletes.ts
@@ -8,7 +8,7 @@ import {
   Timestamp,
 } from 'firebase/firestore';
 import { db } from '../../firebase';
-import { RiderCategory } from '../../core/models/Competidor';
+import { RiderCategory, normalizeCategory } from '../../core/models/Competidor';
 import { Competitor } from '../../core/models/Competidor';
 
 export interface AthleteProfile {
@@ -22,7 +22,7 @@ function toAthleteProfile(id: string, data: any): AthleteProfile {
   return {
     id,
     name: data.name,
-    category: data.category ?? 'Open',
+    category: normalizeCategory(data.category ?? 'Open'),
     createdAt:
       data.createdAt instanceof Timestamp
         ? data.createdAt.toDate().toISOString()

--- a/src/services/firebase/competitions.ts
+++ b/src/services/firebase/competitions.ts
@@ -12,7 +12,7 @@ import {
   Timestamp,
 } from 'firebase/firestore';
 import { db } from '../../firebase';
-import { Competitor } from '../../core/models/Competidor';
+import { Competitor, normalizeCategory } from '../../core/models/Competidor';
 import { Duo } from '../../core/models/Duo';
 import { PassResult } from '../../core/models/PassResult';
 
@@ -72,7 +72,10 @@ function toCompetition(id: string, data: any): Competition {
         : data.updatedAt ?? new Date().toISOString(),
     status: data.status ?? 'draft',
     numRounds: data.numRounds ?? 1,
-    competitors: data.competitors ?? [],
+    competitors: (data.competitors ?? []).map((c: any) => ({
+      ...c,
+      category: normalizeCategory(c.category ?? 'Open'),
+    })),
     duos: data.duos ?? [],
     qualifierResults: data.qualifierResults ?? [],
     finalResults: data.finalResults ?? [],

--- a/src/utils/exportPng.ts
+++ b/src/utils/exportPng.ts
@@ -1,0 +1,171 @@
+interface PngRow {
+  passNumber: number | string;
+  label: string;
+  group: string;
+}
+
+interface PngOptions {
+  title: string;
+  subtitle?: string;
+  rows: PngRow[];
+  fileName: string;
+}
+
+const PADDING = 24;
+const ROW_HEIGHT = 36;
+const HEADER_HEIGHT = 80;
+const FOOTER_HEIGHT = 32;
+const COL_NUM_W = 48;
+const COL_GROUP_W = 52;
+const MIN_WIDTH = 480;
+
+function hexColor(name: string): string {
+  const palette: Record<string, string> = {
+    bg: '#faf8f5',
+    headerBg: '#5c3d2e',
+    headerText: '#ffffff',
+    rowAlt: '#f5f0ea',
+    rowHover: '#ffffff',
+    border: '#e5ddd5',
+    text: '#3d2b1f',
+    muted: '#9a7c6e',
+    badge1D: '#7c4a2e',
+    badge2D: '#2d6a4f',
+    badgeText: '#ffffff',
+  };
+  return palette[name] ?? '#000000';
+}
+
+export function exportDuosToPng(options: PngOptions): void {
+  const { title, subtitle, rows, fileName } = options;
+
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d')!;
+
+  const labelColW = Math.max(MIN_WIDTH - COL_NUM_W - COL_GROUP_W - PADDING * 2, 240);
+  const totalW = COL_NUM_W + labelColW + COL_GROUP_W + PADDING * 2;
+  const totalH = HEADER_HEIGHT + rows.length * ROW_HEIGHT + FOOTER_HEIGHT + PADDING;
+
+  canvas.width = totalW;
+  canvas.height = totalH;
+
+  // Background
+  ctx.fillStyle = hexColor('bg');
+  ctx.fillRect(0, 0, totalW, totalH);
+
+  // Header bar
+  ctx.fillStyle = hexColor('headerBg');
+  ctx.fillRect(0, 0, totalW, HEADER_HEIGHT);
+
+  // Title
+  ctx.fillStyle = hexColor('headerText');
+  ctx.font = 'bold 18px Georgia, serif';
+  ctx.fillText(title, PADDING, 30);
+
+  // Subtitle
+  if (subtitle) {
+    ctx.fillStyle = 'rgba(255,255,255,0.7)';
+    ctx.font = '13px Inter, Arial, sans-serif';
+    ctx.fillText(subtitle, PADDING, 52);
+  }
+
+  // Column header
+  ctx.fillStyle = hexColor('border');
+  ctx.fillRect(0, HEADER_HEIGHT, totalW, 1);
+  ctx.fillStyle = hexColor('muted');
+  ctx.font = 'bold 11px Inter, Arial, sans-serif';
+  const colY = HEADER_HEIGHT + 22;
+  ctx.fillText('#', PADDING + 8, colY);
+  ctx.fillText('DUPLA', PADDING + COL_NUM_W, colY);
+  ctx.fillText('GRP', PADDING + COL_NUM_W + labelColW + 8, colY);
+
+  // Rows
+  rows.forEach((row, i) => {
+    const y = HEADER_HEIGHT + 36 + i * ROW_HEIGHT;
+
+    // Alternating background
+    if (i % 2 === 0) {
+      ctx.fillStyle = hexColor('rowHover');
+    } else {
+      ctx.fillStyle = hexColor('rowAlt');
+    }
+    ctx.fillRect(0, y - ROW_HEIGHT + 6, totalW, ROW_HEIGHT);
+
+    const textY = y;
+
+    // Row number
+    ctx.fillStyle = hexColor('muted');
+    ctx.font = '12px monospace';
+    ctx.textAlign = 'right';
+    ctx.fillText(String(row.passNumber), PADDING + COL_NUM_W - 8, textY);
+
+    // Label
+    ctx.fillStyle = hexColor('text');
+    ctx.font = '13px Inter, Arial, sans-serif';
+    ctx.textAlign = 'left';
+    const maxLabelW = labelColW - 16;
+    let label = row.label;
+    // Truncate if too long
+    while (ctx.measureText(label).width > maxLabelW && label.length > 1) {
+      label = label.slice(0, -4) + '...';
+    }
+    ctx.fillText(label, PADDING + COL_NUM_W, textY);
+
+    // Group badge
+    const badgeX = PADDING + COL_NUM_W + labelColW + 4;
+    const badgeY = y - 14;
+    const badgeW = COL_GROUP_W - 8;
+    const badgeH = 20;
+    const badgeColor = row.group === '1D' ? hexColor('badge1D') : hexColor('badge2D');
+    ctx.fillStyle = badgeColor;
+    roundRect(ctx, badgeX, badgeY, badgeW, badgeH, 10);
+    ctx.fillStyle = hexColor('badgeText');
+    ctx.font = 'bold 11px Inter, Arial, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText(row.group, badgeX + badgeW / 2, y - 1);
+
+    // Row divider
+    ctx.fillStyle = hexColor('border');
+    ctx.fillRect(0, y + 8, totalW, 1);
+  });
+
+  // Footer
+  const footerY = HEADER_HEIGHT + rows.length * ROW_HEIGHT + PADDING + 12;
+  ctx.textAlign = 'center';
+  ctx.fillStyle = hexColor('muted');
+  ctx.font = '11px Inter, Arial, sans-serif';
+  ctx.fillText('Ranch Sorting Pro', totalW / 2, footerY);
+
+  // Download
+  canvas.toBlob((blob) => {
+    if (!blob) return;
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${fileName}.png`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }, 'image/png');
+}
+
+function roundRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number
+): void {
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + w - r, y);
+  ctx.quadraticCurveTo(x + w, y, x + w, y + r);
+  ctx.lineTo(x + w, y + h - r);
+  ctx.quadraticCurveTo(x + w, y + h, x + w - r, y + h);
+  ctx.lineTo(x + r, y + h);
+  ctx.quadraticCurveTo(x, y + h, x, y + h - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
+  ctx.fill();
+}

--- a/src/utils/exportPng.ts
+++ b/src/utils/exportPng.ts
@@ -1,160 +1,39 @@
-interface PngRow {
-  passNumber: number | string;
-  label: string;
-  group: string;
-}
-
-interface PngOptions {
-  title: string;
-  subtitle?: string;
-  rows: PngRow[];
-  fileName: string;
-}
+// ─── Shared helpers ──────────────────────────────────────────────────────────
 
 const PADDING = 24;
 const ROW_HEIGHT = 36;
-const HEADER_HEIGHT = 80;
-const FOOTER_HEIGHT = 32;
-const COL_NUM_W = 48;
-const COL_GROUP_W = 52;
-const MIN_WIDTH = 480;
+const HEADER_HEIGHT = 84;
+const COL_HEADER_H = 32;
+const FOOTER_HEIGHT = 36;
 
-function hexColor(name: string): string {
-  const palette: Record<string, string> = {
-    bg: '#faf8f5',
-    headerBg: '#5c3d2e',
-    headerText: '#ffffff',
-    rowAlt: '#f5f0ea',
-    rowHover: '#ffffff',
-    border: '#e5ddd5',
-    text: '#3d2b1f',
-    muted: '#9a7c6e',
-    badge1D: '#7c4a2e',
-    badge2D: '#2d6a4f',
-    badgeText: '#ffffff',
-  };
+const palette: Record<string, string> = {
+  bg: '#faf8f5',
+  headerBg: '#5c3d2e',
+  headerText: '#ffffff',
+  headerSub: 'rgba(255,255,255,0.65)',
+  colHeaderBg: '#f0ebe4',
+  colHeaderText: '#9a7c6e',
+  rowEven: '#ffffff',
+  rowOdd: '#f7f3ee',
+  rowGold: '#fffbeb',
+  border: '#e5ddd5',
+  text: '#3d2b1f',
+  muted: '#9a7c6e',
+  badge1D: '#7c4a2e',
+  badge2D: '#2d6a4f',
+  badgeText: '#ffffff',
+  sat: '#fee2e2',
+  satText: '#b91c1c',
+  accent: '#5c3d2e',
+};
+
+function px(name: string): string {
   return palette[name] ?? '#000000';
-}
-
-export function exportDuosToPng(options: PngOptions): void {
-  const { title, subtitle, rows, fileName } = options;
-
-  const canvas = document.createElement('canvas');
-  const ctx = canvas.getContext('2d')!;
-
-  const labelColW = Math.max(MIN_WIDTH - COL_NUM_W - COL_GROUP_W - PADDING * 2, 240);
-  const totalW = COL_NUM_W + labelColW + COL_GROUP_W + PADDING * 2;
-  const totalH = HEADER_HEIGHT + rows.length * ROW_HEIGHT + FOOTER_HEIGHT + PADDING;
-
-  canvas.width = totalW;
-  canvas.height = totalH;
-
-  // Background
-  ctx.fillStyle = hexColor('bg');
-  ctx.fillRect(0, 0, totalW, totalH);
-
-  // Header bar
-  ctx.fillStyle = hexColor('headerBg');
-  ctx.fillRect(0, 0, totalW, HEADER_HEIGHT);
-
-  // Title
-  ctx.fillStyle = hexColor('headerText');
-  ctx.font = 'bold 18px Georgia, serif';
-  ctx.fillText(title, PADDING, 30);
-
-  // Subtitle
-  if (subtitle) {
-    ctx.fillStyle = 'rgba(255,255,255,0.7)';
-    ctx.font = '13px Inter, Arial, sans-serif';
-    ctx.fillText(subtitle, PADDING, 52);
-  }
-
-  // Column header
-  ctx.fillStyle = hexColor('border');
-  ctx.fillRect(0, HEADER_HEIGHT, totalW, 1);
-  ctx.fillStyle = hexColor('muted');
-  ctx.font = 'bold 11px Inter, Arial, sans-serif';
-  const colY = HEADER_HEIGHT + 22;
-  ctx.fillText('#', PADDING + 8, colY);
-  ctx.fillText('DUPLA', PADDING + COL_NUM_W, colY);
-  ctx.fillText('GRP', PADDING + COL_NUM_W + labelColW + 8, colY);
-
-  // Rows
-  rows.forEach((row, i) => {
-    const y = HEADER_HEIGHT + 36 + i * ROW_HEIGHT;
-
-    // Alternating background
-    if (i % 2 === 0) {
-      ctx.fillStyle = hexColor('rowHover');
-    } else {
-      ctx.fillStyle = hexColor('rowAlt');
-    }
-    ctx.fillRect(0, y - ROW_HEIGHT + 6, totalW, ROW_HEIGHT);
-
-    const textY = y;
-
-    // Row number
-    ctx.fillStyle = hexColor('muted');
-    ctx.font = '12px monospace';
-    ctx.textAlign = 'right';
-    ctx.fillText(String(row.passNumber), PADDING + COL_NUM_W - 8, textY);
-
-    // Label
-    ctx.fillStyle = hexColor('text');
-    ctx.font = '13px Inter, Arial, sans-serif';
-    ctx.textAlign = 'left';
-    const maxLabelW = labelColW - 16;
-    let label = row.label;
-    // Truncate if too long
-    while (ctx.measureText(label).width > maxLabelW && label.length > 1) {
-      label = label.slice(0, -4) + '...';
-    }
-    ctx.fillText(label, PADDING + COL_NUM_W, textY);
-
-    // Group badge
-    const badgeX = PADDING + COL_NUM_W + labelColW + 4;
-    const badgeY = y - 14;
-    const badgeW = COL_GROUP_W - 8;
-    const badgeH = 20;
-    const badgeColor = row.group === '1D' ? hexColor('badge1D') : hexColor('badge2D');
-    ctx.fillStyle = badgeColor;
-    roundRect(ctx, badgeX, badgeY, badgeW, badgeH, 10);
-    ctx.fillStyle = hexColor('badgeText');
-    ctx.font = 'bold 11px Inter, Arial, sans-serif';
-    ctx.textAlign = 'center';
-    ctx.fillText(row.group, badgeX + badgeW / 2, y - 1);
-
-    // Row divider
-    ctx.fillStyle = hexColor('border');
-    ctx.fillRect(0, y + 8, totalW, 1);
-  });
-
-  // Footer
-  const footerY = HEADER_HEIGHT + rows.length * ROW_HEIGHT + PADDING + 12;
-  ctx.textAlign = 'center';
-  ctx.fillStyle = hexColor('muted');
-  ctx.font = '11px Inter, Arial, sans-serif';
-  ctx.fillText('Ranch Sorting Pro', totalW / 2, footerY);
-
-  // Download
-  canvas.toBlob((blob) => {
-    if (!blob) return;
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `${fileName}.png`;
-    a.click();
-    URL.revokeObjectURL(url);
-  }, 'image/png');
 }
 
 function roundRect(
   ctx: CanvasRenderingContext2D,
-  x: number,
-  y: number,
-  w: number,
-  h: number,
-  r: number
+  x: number, y: number, w: number, h: number, r: number
 ): void {
   ctx.beginPath();
   ctx.moveTo(x + r, y);
@@ -168,4 +47,254 @@ function roundRect(
   ctx.quadraticCurveTo(x, y, x + r, y);
   ctx.closePath();
   ctx.fill();
+}
+
+function truncateText(ctx: CanvasRenderingContext2D, text: string, maxW: number): string {
+  if (ctx.measureText(text).width <= maxW) return text;
+  let t = text;
+  while (t.length > 1 && ctx.measureText(t + '…').width > maxW) {
+    t = t.slice(0, -1);
+  }
+  return t + '…';
+}
+
+function drawHeader(
+  ctx: CanvasRenderingContext2D,
+  totalW: number,
+  title: string,
+  subtitle?: string
+): void {
+  ctx.fillStyle = px('headerBg');
+  ctx.fillRect(0, 0, totalW, HEADER_HEIGHT);
+
+  ctx.fillStyle = px('headerText');
+  ctx.font = 'bold 18px Georgia, serif';
+  ctx.textAlign = 'left';
+  ctx.fillText(truncateText(ctx, title, totalW - PADDING * 2), PADDING, 32);
+
+  if (subtitle) {
+    ctx.fillStyle = px('headerSub');
+    ctx.font = '12px Arial, sans-serif';
+    ctx.fillText(truncateText(ctx, subtitle, totalW - PADDING * 2), PADDING, 54);
+  }
+}
+
+function drawFooter(ctx: CanvasRenderingContext2D, totalW: number, totalH: number): void {
+  ctx.fillStyle = px('colHeaderBg');
+  ctx.fillRect(0, totalH - FOOTER_HEIGHT, totalW, FOOTER_HEIGHT);
+  ctx.fillStyle = px('muted');
+  ctx.font = '11px Arial, sans-serif';
+  ctx.textAlign = 'center';
+  ctx.fillText('Ranch Sorting Pro', totalW / 2, totalH - FOOTER_HEIGHT + 20);
+}
+
+function download(canvas: HTMLCanvasElement, fileName: string): void {
+  canvas.toBlob((blob) => {
+    if (!blob) return;
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${fileName}.png`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }, 'image/png');
+}
+
+// ─── Duo list export (sorteio) ───────────────────────────────────────────────
+
+interface DuoPngRow {
+  passNumber: number | string;
+  label: string;
+  group: string;
+}
+
+interface DuoPngOptions {
+  title: string;
+  subtitle?: string;
+  rows: DuoPngRow[];
+  fileName: string;
+}
+
+export function exportDuosToPng(options: DuoPngOptions): void {
+  const { title, subtitle, rows, fileName } = options;
+
+  const COL_NUM_W = 48;
+  const COL_GROUP_W = 52;
+  const MIN_WIDTH = 520;
+  const labelColW = Math.max(MIN_WIDTH - COL_NUM_W - COL_GROUP_W - PADDING * 2, 240);
+  const totalW = COL_NUM_W + labelColW + COL_GROUP_W + PADDING * 2;
+  const totalH = HEADER_HEIGHT + COL_HEADER_H + rows.length * ROW_HEIGHT + FOOTER_HEIGHT;
+
+  const canvas = document.createElement('canvas');
+  canvas.width = totalW;
+  canvas.height = totalH;
+  const ctx = canvas.getContext('2d')!;
+
+  ctx.fillStyle = px('bg');
+  ctx.fillRect(0, 0, totalW, totalH);
+
+  drawHeader(ctx, totalW, title, subtitle);
+
+  // Column headers
+  const colY = HEADER_HEIGHT + COL_HEADER_H - 10;
+  ctx.fillStyle = px('colHeaderBg');
+  ctx.fillRect(0, HEADER_HEIGHT, totalW, COL_HEADER_H);
+  ctx.fillStyle = px('colHeaderText');
+  ctx.font = 'bold 10px Arial, sans-serif';
+  ctx.textAlign = 'right';
+  ctx.fillText('#', PADDING + COL_NUM_W - 8, colY);
+  ctx.textAlign = 'left';
+  ctx.fillText('DUPLA', PADDING + COL_NUM_W + 4, colY);
+  ctx.fillText('GRP', PADDING + COL_NUM_W + labelColW + 6, colY);
+
+  // Rows
+  rows.forEach((row, i) => {
+    const rowTop = HEADER_HEIGHT + COL_HEADER_H + i * ROW_HEIGHT;
+    ctx.fillStyle = i % 2 === 0 ? px('rowEven') : px('rowOdd');
+    ctx.fillRect(0, rowTop, totalW, ROW_HEIGHT);
+
+    const textY = rowTop + ROW_HEIGHT / 2 + 5;
+
+    ctx.fillStyle = px('muted');
+    ctx.font = '12px monospace';
+    ctx.textAlign = 'right';
+    ctx.fillText(String(row.passNumber), PADDING + COL_NUM_W - 8, textY);
+
+    ctx.fillStyle = px('text');
+    ctx.font = '13px Arial, sans-serif';
+    ctx.textAlign = 'left';
+    ctx.fillText(truncateText(ctx, row.label, labelColW - 16), PADDING + COL_NUM_W + 4, textY);
+
+    // Badge
+    const bx = PADDING + COL_NUM_W + labelColW + 4;
+    const bw = COL_GROUP_W - 12;
+    const bh = 20;
+    const by = rowTop + (ROW_HEIGHT - bh) / 2;
+    ctx.fillStyle = row.group === '1D' ? px('badge1D') : px('badge2D');
+    roundRect(ctx, bx, by, bw, bh, 10);
+    ctx.fillStyle = px('badgeText');
+    ctx.font = 'bold 10px Arial, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText(row.group, bx + bw / 2, by + 14);
+
+    ctx.fillStyle = px('border');
+    ctx.fillRect(0, rowTop + ROW_HEIGHT - 1, totalW, 1);
+  });
+
+  drawFooter(ctx, totalW, totalH);
+  download(canvas, fileName);
+}
+
+// ─── Results table export (qualificatórias / finais) ─────────────────────────
+
+export interface ResultColumn {
+  header: string;
+  width: number;
+  align?: 'left' | 'right' | 'center';
+}
+
+export interface ResultPngRow {
+  cells: string[];
+  highlight?: boolean; // gold bg for top positions
+  isSAT?: boolean;
+  isGroupHeader?: boolean; // renders a section divider row
+}
+
+export interface ResultsPngOptions {
+  title: string;
+  subtitle?: string;
+  columns: ResultColumn[];
+  rows: ResultPngRow[];
+  fileName: string;
+}
+
+export function exportResultsToPng(options: ResultsPngOptions): void {
+  const { title, subtitle, columns, rows, fileName } = options;
+
+  const totalColW = columns.reduce((s, c) => s + c.width, 0);
+  const totalW = totalColW + PADDING * 2;
+  const totalH = HEADER_HEIGHT + COL_HEADER_H + rows.length * ROW_HEIGHT + FOOTER_HEIGHT;
+
+  const canvas = document.createElement('canvas');
+  canvas.width = totalW;
+  canvas.height = totalH;
+  const ctx = canvas.getContext('2d')!;
+
+  ctx.fillStyle = px('bg');
+  ctx.fillRect(0, 0, totalW, totalH);
+
+  drawHeader(ctx, totalW, title, subtitle);
+
+  // Column headers
+  ctx.fillStyle = px('colHeaderBg');
+  ctx.fillRect(0, HEADER_HEIGHT, totalW, COL_HEADER_H);
+  ctx.fillStyle = px('colHeaderText');
+  ctx.font = 'bold 10px Arial, sans-serif';
+
+  let colX = PADDING;
+  for (const col of columns) {
+    ctx.textAlign = col.align === 'left' ? 'left' : col.align === 'right' ? 'right' : 'center';
+    const hx = col.align === 'left' ? colX + 4 : col.align === 'right' ? colX + col.width - 4 : colX + col.width / 2;
+    ctx.fillText(col.header, hx, HEADER_HEIGHT + COL_HEADER_H - 10);
+    colX += col.width;
+  }
+
+  // Rows
+  rows.forEach((row, i) => {
+    const rowTop = HEADER_HEIGHT + COL_HEADER_H + i * ROW_HEIGHT;
+
+    if (row.isGroupHeader) {
+      ctx.fillStyle = px('colHeaderBg');
+      ctx.fillRect(0, rowTop, totalW, ROW_HEIGHT);
+      ctx.fillStyle = px('accent');
+      ctx.font = 'bold 11px Arial, sans-serif';
+      ctx.textAlign = 'left';
+      ctx.fillText(row.cells[0] ?? '', PADDING + 8, rowTop + ROW_HEIGHT / 2 + 4);
+      ctx.fillStyle = px('border');
+      ctx.fillRect(0, rowTop + ROW_HEIGHT - 1, totalW, 1);
+      return;
+    }
+
+    let rowBg = i % 2 === 0 ? px('rowEven') : px('rowOdd');
+    if (row.highlight) rowBg = px('rowGold');
+    if (row.isSAT) rowBg = px('sat');
+    ctx.fillStyle = rowBg;
+    ctx.fillRect(0, rowTop, totalW, ROW_HEIGHT);
+
+    const textY = rowTop + ROW_HEIGHT / 2 + 5;
+    let cx = PADDING;
+
+    row.cells.forEach((cell, ci) => {
+      const col = columns[ci];
+      if (!col) return;
+      const align = col.align ?? 'center';
+      ctx.textAlign = align;
+      const tx = align === 'left' ? cx + 4 : align === 'right' ? cx + col.width - 4 : cx + col.width / 2;
+
+      if (row.isSAT && cell === 'SAT') {
+        ctx.fillStyle = px('satText');
+        ctx.font = 'bold 11px Arial, sans-serif';
+      } else if (ci === 0) {
+        ctx.fillStyle = px('muted');
+        ctx.font = '11px monospace';
+      } else if (ci === 1) {
+        ctx.fillStyle = px('text');
+        ctx.font = '13px Arial, sans-serif';
+        const maxW = col.width - 8;
+        cell = truncateText(ctx, cell, maxW);
+      } else {
+        ctx.fillStyle = px('text');
+        ctx.font = '12px Arial, sans-serif';
+      }
+
+      ctx.fillText(cell, tx, textY);
+      cx += col.width;
+    });
+
+    ctx.fillStyle = px('border');
+    ctx.fillRect(0, rowTop + ROW_HEIGHT - 1, totalW, 1);
+  });
+
+  drawFooter(ctx, totalW, totalH);
+  download(canvas, fileName);
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Resumo

Implementação de múltiplas melhorias de produto abrangendo responsividade mobile, simplificação do modelo de categorias, novos fluxos de exportação (PNG via Canvas API) e refinamentos de UX em todas as telas principais.

---

## Mudanças por área

### Modelo de dados
- **Simplificação de categorias**: `RiderCategory` reduzido para `'Open' | 'AmateurLight'`; adicionada `normalizeCategory()` que migra automaticamente dados legados (`Amateur19 → Open`, `Beginner → AmateurLight`) ao carregar do Firebase
- **`core/models/Competidor.ts`**, **`core/models/Duo.ts`**: VALID_PAIRINGS e computeDuoGroup simplificados para 2 categorias
- **`services/firebase/competitions.ts`**, **`services/firebase/athletes.ts`**: normalização aplicada no carregamento

### Exibição de Duplas
- Removidos `CategoryBadge` individuais da lista de duplas — exibição no formato `"Competidor A & Competidor B"` sem badges por rider
- Layout com `flex-1 min-w-0 truncate` para não depender do tamanho do nome

### Exportação PNG (Canvas API — sem nova dependência)
- Novo `utils/exportPng.ts` com dois exportadores:
  - `exportDuosToPng()` — lista de duplas do sorteio
  - `exportResultsToPng()` — tabela genérica de resultados multi-coluna
- **Qualificatórias**: botões **Planilha** + **PNG** (ranking 1D e 2D em seções separadas, SATs em vermelho, 1º lugar dourado)
- **Final**: botões **Planilha {tab}** + **PNG {tab}** por aba ativa (colunas B.C, Q.B, Q.T, F.B, F.T, Méd.B, Méd.T; top 3 dourado)
- **Duplas**: botões **Planilha** + **PNG** gerais; botão **Por Competidor** abre modal com busca → exporta Planilha ou PNG individual por competidor selecionado

### Formulários de Classificatórias e Finais
- Removidos sufixos `(0–9)` e `(0–10)` dos labels do `QuickSelect`
- Adicionado fluxo alternativo de seleção manual de dupla: botão discreto "Escolher outra dupla" abre modal com lista de pendentes; fila original preservada

### Responsividade Mobile
- `CompetitionLayout.tsx`: nav com labels visíveis em mobile (ícone + texto em coluna, `text-[10px]`)
- Todas as telas com grade `lg:grid-cols-5`: adicionado `md:grid-cols-2` para tablet/mobile médio
- `Announcer`: cards com padding e fontes responsivos; "Última passada" com `break-words`

### Histórico do Competidor
- Adicionado bloco de estatísticas para a seção **Final** (média de bois, tempo médio, quantidade de SATs) — já existia apenas nas Qualificatórias

### Visão do Locutor
- Indicadores de estatísticas compactos para mobile (`gap-2 sm:gap-3`)

---

## Checklist de testes

- [ ] Criar competição → adicionar Profissional + Amador → sortear → verificar lista numerada sem CategoryBadges
- [ ] Competição legada com `Amateur19`/`Beginner` → verificar normalização ao carregar
- [ ] Qualificatórias: registrar resultado, testar "Escolher outra dupla", exportar Planilha + PNG
- [ ] Final: testar bloqueio de 1D até 2D concluir, exportar Planilha {tab} + PNG {tab}
- [ ] Duplas: exportar PNG geral + por competidor via modal
- [ ] Histórico: verificar stats de finais
- [ ] Testar layout em viewport mobile (≤ 375px)

https://claude.ai/code/session_01HQ5cyA6UGw2nqLuBoPEPvi
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HQ5cyA6UGw2nqLuBoPEPvi)_