### PR TITLE
feat: implement competitor portal with auto-linking architecture

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ import PortalDashboard from './screens/competitor/portal/Dashboard';
 import MyCompetitionsPage from './screens/competitor/portal/MyCompetitionsPage';
 import MyPassesPage from './screens/competitor/portal/MyPassesPage';
 import CompetitionResults from './screens/competitor/portal/CompetitionResults';
+import ClaimProfile from './screens/competitor/portal/ClaimProfile';
 
 export default function App() {
   return (
@@ -55,6 +56,7 @@ export default function App() {
                   <Route path="/portal" element={<PortalDashboard />}>
                     <Route index element={<MyCompetitionsPage />} />
                     <Route path="passes" element={<MyPassesPage />} />
+                    <Route path="claim" element={<ClaimProfile />} />
                     <Route path="results/:competitionId" element={<CompetitionResults />} />
                   </Route>
                 </Route>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,17 @@ import RoundsOverview from './screens/RoundsOverview';
 import CompetitorHistory from './screens/CompetitorHistory';
 import Announcer from './screens/Announcer';
 
+// Competitor Portal — public pages
+import CompetitorLanding from './screens/competitor/Landing';
+import CompetitorSearch from './screens/competitor/Search';
+import CompetitorPublicProfile from './screens/competitor/PublicProfile';
+
+// Competitor Portal — authenticated pages
+import PortalDashboard from './screens/competitor/portal/Dashboard';
+import MyCompetitionsPage from './screens/competitor/portal/MyCompetitionsPage';
+import MyPassesPage from './screens/competitor/portal/MyPassesPage';
+import CompetitionResults from './screens/competitor/portal/CompetitionResults';
+
 export default function App() {
   return (
     <AuthProvider>
@@ -34,7 +45,21 @@ export default function App() {
                 <Route path="/login" element={<LoginScreen />} />
                 <Route path="/register" element={<RegisterScreen />} />
 
-                {/* Protected */}
+                {/* Competitor Portal — public (no login required) */}
+                <Route path="/competitor" element={<CompetitorLanding />} />
+                <Route path="/competitor/search" element={<CompetitorSearch />} />
+                <Route path="/competitor/profile/:profileId" element={<CompetitorPublicProfile />} />
+
+                {/* Competitor Portal — authenticated */}
+                <Route element={<PrivateRoute />}>
+                  <Route path="/portal" element={<PortalDashboard />}>
+                    <Route index element={<MyCompetitionsPage />} />
+                    <Route path="passes" element={<MyPassesPage />} />
+                    <Route path="results/:competitionId" element={<CompetitionResults />} />
+                  </Route>
+                </Route>
+
+                {/* Organizer protected routes */}
                 <Route element={<PrivateRoute />}>
                   <Route path="/" element={<DashboardScreen />} />
 

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -9,7 +9,9 @@ export type UserRole = 'basic' | 'pro';
 interface AuthContextValue {
   user: User | null;
   role: UserRole;
+  competitorProfileId: string | null;
   isLoading: boolean;
+  refreshUserDoc: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
@@ -17,28 +19,41 @@ const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [role, setRole] = useState<UserRole>('basic');
+  const [competitorProfileId, setCompetitorProfileId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+
+  async function loadUserDoc(u: User) {
+    try {
+      const snap = await getDoc(doc(db, 'users', u.uid));
+      const data = snap.data();
+      setRole((data?.role as UserRole) ?? 'basic');
+      setCompetitorProfileId(data?.competitorProfileId ?? null);
+    } catch {
+      setRole('basic');
+      setCompetitorProfileId(null);
+    }
+  }
+
+  async function refreshUserDoc() {
+    if (user) await loadUserDoc(user);
+  }
 
   useEffect(() => {
     const unsubscribe = onAuthChange(async (u) => {
       setUser(u);
       if (u) {
-        try {
-          const snap = await getDoc(doc(db, 'users', u.uid));
-          setRole((snap.data()?.role as UserRole) ?? 'basic');
-        } catch {
-          setRole('basic');
-        }
+        await loadUserDoc(u);
       } else {
         setRole('basic');
+        setCompetitorProfileId(null);
       }
       setIsLoading(false);
     });
     return unsubscribe;
-  }, []);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
-    <AuthContext.Provider value={{ user, role, isLoading }}>
+    <AuthContext.Provider value={{ user, role, competitorProfileId, isLoading, refreshUserDoc }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/core/models/Competidor.ts
+++ b/src/core/models/Competidor.ts
@@ -12,6 +12,4 @@ export interface Competitor {
   category: RiderCategory;
   // Number of passes (rounds) this competitor must ride in the qualifier stage
   passes: number;
-  // Optional link to the global CompetitorProfile (populated by auto-linking)
-  profileId?: string;
 }

--- a/src/core/models/Competidor.ts
+++ b/src/core/models/Competidor.ts
@@ -12,4 +12,6 @@ export interface Competitor {
   category: RiderCategory;
   // Number of passes (rounds) this competitor must ride in the qualifier stage
   passes: number;
+  // Optional link to the global CompetitorProfile (populated by auto-linking)
+  profileId?: string;
 }

--- a/src/core/models/CompetitorProfile.ts
+++ b/src/core/models/CompetitorProfile.ts
@@ -1,0 +1,24 @@
+export interface CompetitorProfile {
+  id: string;
+  displayName: string;
+  aliases: string[];
+  normalizedName: string;
+  userId?: string;
+  email?: string;
+  status: 'unclaimed' | 'claimed' | 'merged';
+  mergedIntoProfileId?: string;
+  createdAt: string;
+  updatedAt: string;
+  claimedAt?: string;
+}
+
+export interface CompetitorLink {
+  id: string;
+  profileId: string;
+  competitionId: string;
+  competitorId: string;
+  matchType: 'auto_exact' | 'auto_fuzzy' | 'organizer' | 'claimed';
+  confidence: number;
+  createdAt: string;
+  createdBy?: string;
+}

--- a/src/screens/Dashboard/index.tsx
+++ b/src/screens/Dashboard/index.tsx
@@ -116,6 +116,14 @@ export default function DashboardScreen() {
           <span className="text-saddle-200 text-sm hidden sm:block">
             Olá, {user?.displayName ?? user?.email}
           </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => navigate('/portal')}
+            className="text-saddle-200 hover:text-white hover:bg-saddle-700 hidden sm:inline-flex"
+          >
+            Meu Portal
+          </Button>
           <Button variant="ghost" size="sm" onClick={handleLogout}
             className="text-saddle-200 hover:text-white hover:bg-saddle-700">
             Sair

--- a/src/screens/Registration/index.tsx
+++ b/src/screens/Registration/index.tsx
@@ -21,6 +21,7 @@ import {
   saveAthlete,
   importProfilesAsCompetitors,
 } from '../../services/firebase/athletes';
+import { tryAutoLinkCompetitor } from '../../services/competitorLinking';
 
 const CATEGORIES: { label: string; value: RiderCategory; hint: string }[] = [
   { label: 'Profissional', value: 'Open', hint: 'Grupo 1D' },
@@ -77,6 +78,9 @@ export default function Registration() {
       passes: numRounds,
     };
     setCompetitors([...competitors, newCompetitor]);
+
+    // Auto-link in background — fire and forget, never blocks the organizer
+    if (id) tryAutoLinkCompetitor(newCompetitor, id);
 
     if (saveToBase && user?.uid) {
       try {
@@ -169,6 +173,8 @@ export default function Registration() {
       toast('Todos os atletas selecionados já estão cadastrados.', 'info');
     } else {
       setCompetitors([...competitors, ...toAdd]);
+      // Auto-link all imported competitors in background
+      if (id) toAdd.forEach((c) => tryAutoLinkCompetitor(c, id));
       toast(`${toAdd.length} atleta(s) importado(s)!`, 'success');
     }
     setAthletePickerOpen(false);

--- a/src/screens/competitor/Landing/index.tsx
+++ b/src/screens/competitor/Landing/index.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Button } from '../../../components/ui/Button';
+
+export default function CompetitorLanding() {
+  return (
+    <div className="min-h-screen bg-dust-100 flex flex-col">
+      {/* Hero */}
+      <div className="bg-saddle-800 text-white py-20 px-6 flex-1 flex items-center justify-center">
+        <div className="max-w-2xl text-center">
+          <div className="text-7xl mb-6">🐄</div>
+          <h1 className="font-serif font-bold text-4xl md:text-5xl mb-4 leading-tight">
+            Portal do Competidor
+          </h1>
+          <p className="text-saddle-200 text-lg mb-10 max-w-xl mx-auto">
+            Acesse seu histórico de competições, passadas e resultados de Ranch Sorting — em um só lugar.
+          </p>
+
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <Link to="/competitor/search">
+              <Button variant="secondary" size="lg">
+                Buscar meu perfil
+              </Button>
+            </Link>
+            <Link to="/login">
+              <Button variant="outline" size="lg" className="text-white border-white hover:bg-saddle-700">
+                Entrar / Criar conta
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      {/* Features */}
+      <div className="bg-white py-16 px-6">
+        <div className="max-w-4xl mx-auto grid grid-cols-1 md:grid-cols-3 gap-8 text-center">
+          <div className="flex flex-col items-center gap-3">
+            <span className="text-4xl">📋</span>
+            <h3 className="font-serif font-semibold text-rope-800 text-lg">Histórico completo</h3>
+            <p className="text-rope-400 text-sm">
+              Veja todas as suas passadas em qualificatórias e finais, organizadas por competição.
+            </p>
+          </div>
+          <div className="flex flex-col items-center gap-3">
+            <span className="text-4xl">🏆</span>
+            <h3 className="font-serif font-semibold text-rope-800 text-lg">Resultados</h3>
+            <p className="text-rope-400 text-sm">
+              Acompanhe seu desempenho e resultados nas competições em que participou.
+            </p>
+          </div>
+          <div className="flex flex-col items-center gap-3">
+            <span className="text-4xl">🔗</span>
+            <h3 className="font-serif font-semibold text-rope-800 text-lg">Sem burocracia</h3>
+            <p className="text-rope-400 text-sm">
+              Você não precisa de conta para competir. Crie seu acesso depois, a qualquer hora.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <footer className="bg-dust-200 text-center text-rope-400 text-xs py-4">
+        Ranch Sorting Pro · Portal do Competidor
+      </footer>
+    </div>
+  );
+}

--- a/src/screens/competitor/PublicProfile/index.tsx
+++ b/src/screens/competitor/PublicProfile/index.tsx
@@ -1,0 +1,176 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { CompetitorProfile } from '../../../core/models/CompetitorProfile';
+import { getCompetitorProfile } from '../../../services/firebase/competitorProfiles';
+import {
+  getCompetitorHistory,
+  CompetitionHistoryEntry,
+} from '../../../services/firebase/competitorHistory';
+import { Button } from '../../../components/ui/Button';
+import { Card } from '../../../components/ui/Card';
+import { Spinner } from '../../../components/ui/Spinner';
+import { EmptyState } from '../../../components/ui/EmptyState';
+
+export default function CompetitorPublicProfile() {
+  const { profileId } = useParams<{ profileId: string }>();
+  const navigate = useNavigate();
+
+  const [profile, setProfile] = useState<CompetitorProfile | null>(null);
+  const [history, setHistory] = useState<CompetitionHistoryEntry[]>([]);
+  const [loadingProfile, setLoadingProfile] = useState(true);
+  const [loadingHistory, setLoadingHistory] = useState(false);
+
+  useEffect(() => {
+    if (!profileId) return;
+    setLoadingProfile(true);
+    getCompetitorProfile(profileId)
+      .then((p) => {
+        setProfile(p);
+        if (p) {
+          setLoadingHistory(true);
+          return getCompetitorHistory(p.id);
+        }
+        return [];
+      })
+      .then(setHistory)
+      .catch(() => {})
+      .finally(() => {
+        setLoadingProfile(false);
+        setLoadingHistory(false);
+      });
+  }, [profileId]);
+
+  if (loadingProfile) {
+    return (
+      <div className="min-h-screen bg-dust-100 flex items-center justify-center">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (!profile) {
+    return (
+      <div className="min-h-screen bg-dust-100 flex items-center justify-center">
+        <EmptyState
+          icon="👤"
+          title="Perfil não encontrado"
+          description="Este perfil não existe ou foi removido."
+          action={<Button variant="outline" onClick={() => navigate('/competitor/search')}>Buscar outro perfil</Button>}
+        />
+      </div>
+    );
+  }
+
+  const totalCattle = history.flatMap((h) => h.passes).reduce((s, p) => s + p.cattleCount, 0);
+  const totalPasses = history.flatMap((h) => h.passes).length;
+
+  return (
+    <div className="min-h-screen bg-dust-100">
+      <header className="bg-saddle-800 text-white px-6 py-4 flex items-center gap-4 shadow-md">
+        <button
+          onClick={() => navigate('/competitor/search')}
+          className="text-saddle-300 hover:text-white transition-colors p-1"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+        </button>
+        <div>
+          <h1 className="font-serif font-bold text-lg">{profile.displayName}</h1>
+          <p className="text-saddle-300 text-xs">Perfil público · Ranch Sorting Pro</p>
+        </div>
+      </header>
+
+      <main className="max-w-3xl mx-auto px-4 py-8 flex flex-col gap-6">
+        {/* Profile card */}
+        <Card>
+          <div className="flex items-center justify-between gap-4 flex-wrap">
+            <div>
+              <h2 className="font-serif font-bold text-rope-800 text-2xl">{profile.displayName}</h2>
+              <span
+                className={[
+                  'text-xs px-2 py-0.5 rounded-full font-medium mt-2 inline-block',
+                  profile.status === 'claimed'
+                    ? 'bg-green-100 text-green-700'
+                    : 'bg-hay-100 text-hay-700',
+                ].join(' ')}
+              >
+                {profile.status === 'claimed' ? 'Perfil reivindicado' : 'Perfil disponível para reivindicação'}
+              </span>
+            </div>
+            {profile.status !== 'claimed' && (
+              <Link to={`/portal/claim?profileId=${profile.id}`}>
+                <Button>Este sou eu</Button>
+              </Link>
+            )}
+          </div>
+
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-4 mt-5 pt-5 border-t border-dust-200">
+            <div className="text-center">
+              <p className="text-2xl font-bold text-saddle-700">{history.length}</p>
+              <p className="text-xs text-rope-400 mt-0.5">Competições</p>
+            </div>
+            <div className="text-center">
+              <p className="text-2xl font-bold text-saddle-700">{totalPasses}</p>
+              <p className="text-xs text-rope-400 mt-0.5">Passadas</p>
+            </div>
+            <div className="text-center">
+              <p className="text-2xl font-bold text-saddle-700">{totalCattle}</p>
+              <p className="text-xs text-rope-400 mt-0.5">Total de bois</p>
+            </div>
+          </div>
+        </Card>
+
+        {/* Competition history */}
+        <Card title="Competições" noPadding>
+          {loadingHistory ? (
+            <div className="flex justify-center py-8">
+              <Spinner size="lg" />
+            </div>
+          ) : history.length === 0 ? (
+            <EmptyState
+              icon="📋"
+              title="Nenhuma competição registrada"
+              description="As competições aparecerão aqui quando forem vinculadas a este perfil."
+            />
+          ) : (
+            <ul className="divide-y divide-dust-200">
+              {history.map((entry) => (
+                <CompetitionRow key={entry.competitionId} entry={entry} />
+              ))}
+            </ul>
+          )}
+        </Card>
+      </main>
+    </div>
+  );
+}
+
+function CompetitionRow({ entry }: { entry: CompetitionHistoryEntry }) {
+  const date = entry.eventDate
+    ? new Date(entry.eventDate + 'T12:00').toLocaleDateString('pt-BR', {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+      })
+    : null;
+  const totalCattle = entry.passes.reduce((s, p) => s + p.cattleCount, 0);
+
+  return (
+    <li className="px-5 py-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="font-semibold text-rope-800 text-sm">{entry.competitionName}</p>
+          {entry.location && (
+            <p className="text-rope-400 text-xs mt-0.5">📍 {entry.location}</p>
+          )}
+          {date && <p className="text-rope-400 text-xs mt-0.5">📅 {date}</p>}
+        </div>
+        <div className="text-right shrink-0">
+          <p className="text-sm font-semibold text-saddle-700">{totalCattle} bois</p>
+          <p className="text-xs text-rope-400">{entry.passes.length} passada{entry.passes.length !== 1 ? 's' : ''}</p>
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/src/screens/competitor/Search/index.tsx
+++ b/src/screens/competitor/Search/index.tsx
@@ -1,0 +1,142 @@
+import React, { useState, useRef } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { CompetitorProfile } from '../../../core/models/CompetitorProfile';
+import { searchProfilesForUser } from '../../../services/firebase/competitorProfiles';
+import { Button } from '../../../components/ui/Button';
+import { Input } from '../../../components/ui/Input';
+import { Card } from '../../../components/ui/Card';
+import { Spinner } from '../../../components/ui/Spinner';
+
+export default function CompetitorSearch() {
+  const navigate = useNavigate();
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<Array<{ profile: CompetitorProfile; score: number }>>([]);
+  const [searched, setSearched] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  async function handleSearch() {
+    const q = query.trim();
+    if (!q) return;
+    setLoading(true);
+    setSearched(false);
+    try {
+      const found = await searchProfilesForUser(q);
+      setResults(found);
+    } catch {
+      setResults([]);
+    } finally {
+      setLoading(false);
+      setSearched(true);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-dust-100">
+      <header className="bg-saddle-800 text-white px-6 py-4 flex items-center gap-4 shadow-md">
+        <button
+          onClick={() => navigate('/competitor')}
+          className="text-saddle-300 hover:text-white transition-colors p-1"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+        </button>
+        <div>
+          <h1 className="font-serif font-bold text-lg">Buscar Perfil</h1>
+          <p className="text-saddle-300 text-xs">Encontre seu histórico de competidor</p>
+        </div>
+      </header>
+
+      <main className="max-w-2xl mx-auto px-4 py-8">
+        <Card title="Pesquisar por nome">
+          <div className="flex gap-2">
+            <div className="flex-1">
+              <Input
+                ref={inputRef}
+                placeholder="Ex: João da Silva"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+                autoFocus
+              />
+            </div>
+            <Button onClick={handleSearch} loading={loading} className="shrink-0">
+              Buscar
+            </Button>
+          </div>
+          <p className="text-xs text-rope-400 mt-2">
+            Digite o nome como foi cadastrado pelo organizador da competição.
+          </p>
+        </Card>
+
+        {loading && (
+          <div className="flex justify-center py-12">
+            <Spinner size="lg" />
+          </div>
+        )}
+
+        {searched && !loading && (
+          <div className="mt-6">
+            {results.length === 0 ? (
+              <Card>
+                <div className="text-center py-6">
+                  <p className="text-rope-400 mb-4">Nenhum perfil encontrado para "{query}".</p>
+                  <p className="text-rope-500 text-sm mb-6">
+                    Seu nome pode estar cadastrado de forma diferente. Tente variações ou verifique com o organizador.
+                  </p>
+                  <Link to="/login">
+                    <Button variant="outline">Criar conta e perfil manual</Button>
+                  </Link>
+                </div>
+              </Card>
+            ) : (
+              <div className="flex flex-col gap-3">
+                <p className="text-sm text-rope-500 font-medium">
+                  {results.length} perfil{results.length !== 1 ? 'is' : ''} encontrado{results.length !== 1 ? 's' : ''}
+                </p>
+                {results.map(({ profile }) => (
+                  <ProfileCard key={profile.id} profile={profile} />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}
+
+function ProfileCard({ profile }: { profile: CompetitorProfile }) {
+  return (
+    <Card>
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h3 className="font-semibold text-rope-800">{profile.displayName}</h3>
+          <div className="flex items-center gap-2 mt-1">
+            <span
+              className={[
+                'text-xs px-2 py-0.5 rounded-full font-medium',
+                profile.status === 'claimed'
+                  ? 'bg-green-100 text-green-700'
+                  : 'bg-hay-100 text-hay-700',
+              ].join(' ')}
+            >
+              {profile.status === 'claimed' ? 'Perfil reivindicado' : 'Perfil livre'}
+            </span>
+          </div>
+        </div>
+        <div className="flex gap-2 shrink-0">
+          <Link to={`/competitor/profile/${profile.id}`}>
+            <Button variant="outline" size="sm">Ver histórico</Button>
+          </Link>
+          {profile.status !== 'claimed' && (
+            <Link to={`/portal/claim?profileId=${profile.id}`}>
+              <Button size="sm">Este sou eu</Button>
+            </Link>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/screens/competitor/Search/index.tsx
+++ b/src/screens/competitor/Search/index.tsx
@@ -93,7 +93,7 @@ export default function CompetitorSearch() {
             ) : (
               <div className="flex flex-col gap-3">
                 <p className="text-sm text-rope-500 font-medium">
-                  {results.length} perfil{results.length !== 1 ? 'is' : ''} encontrado{results.length !== 1 ? 's' : ''}
+                  {results.length !== 1 ? `${results.length} perfis encontrados` : '1 perfil encontrado'}
                 </p>
                 {results.map(({ profile }) => (
                   <ProfileCard key={profile.id} profile={profile} />

--- a/src/screens/competitor/portal/ClaimProfile/index.tsx
+++ b/src/screens/competitor/portal/ClaimProfile/index.tsx
@@ -1,0 +1,193 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { CompetitorProfile } from '../../../../core/models/CompetitorProfile';
+import {
+  searchProfilesForUser,
+  getCompetitorProfile,
+  claimCompetitorProfile,
+  createCompetitorProfile,
+} from '../../../../services/firebase/competitorProfiles';
+import { useAuth } from '../../../../context/AuthContext';
+import { useToast } from '../../../../components/ui/Toast';
+import { Button } from '../../../../components/ui/Button';
+import { Input } from '../../../../components/ui/Input';
+import { Card } from '../../../../components/ui/Card';
+import { Spinner } from '../../../../components/ui/Spinner';
+
+export default function ClaimProfile() {
+  const { user, competitorProfileId, refreshUserDoc } = useAuth();
+  const navigate = useNavigate();
+  const toast = useToast();
+  const [params] = useSearchParams();
+  const preselectedId = params.get('profileId');
+
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<Array<{ profile: CompetitorProfile; score: number }>>([]);
+  const [searched, setSearched] = useState(false);
+  const [loadingSearch, setLoadingSearch] = useState(false);
+  const [claimingId, setClaimingId] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+
+  // If a profileId was pre-selected (from public search), load it
+  useEffect(() => {
+    if (!preselectedId) return;
+    getCompetitorProfile(preselectedId).then((p) => {
+      if (p) setResults([{ profile: p, score: 1 }]);
+      setSearched(true);
+    });
+  }, [preselectedId]);
+
+  if (!user) return null;
+
+  async function handleSearch() {
+    if (!query.trim()) return;
+    setLoadingSearch(true);
+    setSearched(false);
+    try {
+      const found = await searchProfilesForUser(query.trim());
+      setResults(found);
+    } catch {
+      setResults([]);
+    } finally {
+      setLoadingSearch(false);
+      setSearched(true);
+    }
+  }
+
+  async function handleClaim(profile: CompetitorProfile) {
+    if (!user?.email) return;
+    setClaimingId(profile.id);
+    try {
+      await claimCompetitorProfile(profile.id, user.uid, user.email);
+      await refreshUserDoc();
+      toast(`Perfil "${profile.displayName}" vinculado com sucesso!`, 'success');
+      navigate('/portal');
+    } catch {
+      toast('Erro ao vincular perfil. Tente novamente.', 'error');
+    } finally {
+      setClaimingId(null);
+    }
+  }
+
+  async function handleCreateNew() {
+    if (!user?.displayName && !user?.email) return;
+    const name = user.displayName || user.email!.split('@')[0];
+    setCreating(true);
+    try {
+      const profile = await createCompetitorProfile(name, user.uid, user.email ?? undefined);
+      await refreshUserDoc();
+      toast(`Perfil "${profile.displayName}" criado com sucesso!`, 'success');
+      navigate('/portal');
+    } catch {
+      toast('Erro ao criar perfil. Tente novamente.', 'error');
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <h2 className="font-serif font-bold text-rope-800 text-xl mb-1">Vincular meu perfil</h2>
+        <p className="text-rope-400 text-sm">
+          Busque pelo nome que o organizador usou para te cadastrar nas competições.
+        </p>
+      </div>
+
+      {/* Already has a profile */}
+      {competitorProfileId && (
+        <div className="bg-green-50 border border-green-200 rounded-xl p-4 text-sm text-green-800">
+          Você já possui um perfil vinculado.{' '}
+          <button onClick={() => navigate('/portal')} className="underline font-medium">
+            Ir para o portal
+          </button>
+        </div>
+      )}
+
+      {/* Search box */}
+      <Card title="Pesquisar pelo nome">
+        <div className="flex gap-2">
+          <div className="flex-1">
+            <Input
+              placeholder="Ex: João da Silva"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+              autoFocus={!preselectedId}
+            />
+          </div>
+          <Button onClick={handleSearch} loading={loadingSearch} className="shrink-0">
+            Buscar
+          </Button>
+        </div>
+      </Card>
+
+      {loadingSearch && (
+        <div className="flex justify-center py-6">
+          <Spinner size="lg" />
+        </div>
+      )}
+
+      {/* Results */}
+      {searched && !loadingSearch && (
+        <>
+          {results.length === 0 ? (
+            <Card>
+              <div className="text-center py-4">
+                <p className="text-rope-400 mb-2">Nenhum perfil encontrado.</p>
+                <p className="text-rope-500 text-sm mb-4">
+                  Isso pode acontecer se você ainda não foi cadastrado em nenhuma competição, ou se o nome foi digitado diferente.
+                </p>
+              </div>
+            </Card>
+          ) : (
+            <div className="flex flex-col gap-3">
+              <p className="text-sm text-rope-500 font-medium">
+                {results.length} perfil{results.length !== 1 ? 'is' : ''} encontrado{results.length !== 1 ? 's' : ''}. Selecione o seu:
+              </p>
+              {results.map(({ profile }) => (
+                <Card key={profile.id}>
+                  <div className="flex items-center justify-between gap-4 flex-wrap">
+                    <div>
+                      <p className="font-semibold text-rope-800">{profile.displayName}</p>
+                      {profile.status === 'claimed' ? (
+                        <span className="text-xs text-green-600 font-medium">Perfil já reivindicado</span>
+                      ) : (
+                        <span className="text-xs text-rope-400">Perfil disponível</span>
+                      )}
+                    </div>
+                    {profile.status !== 'claimed' && (
+                      <Button
+                        size="sm"
+                        onClick={() => handleClaim(profile)}
+                        loading={claimingId === profile.id}
+                        disabled={!!claimingId || !!competitorProfileId}
+                      >
+                        Este sou eu
+                      </Button>
+                    )}
+                  </div>
+                </Card>
+              ))}
+            </div>
+          )}
+
+          {/* Create new profile option */}
+          <div className="border-t border-dust-300 pt-5 mt-2">
+            <p className="text-sm text-rope-500 mb-3">
+              Não encontrou seu perfil? Crie um novo:
+            </p>
+            <Button
+              variant="outline"
+              onClick={handleCreateNew}
+              loading={creating}
+              disabled={!!claimingId || !!competitorProfileId}
+            >
+              Criar perfil com meu nome
+            </Button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/screens/competitor/portal/ClaimProfile/index.tsx
+++ b/src/screens/competitor/portal/ClaimProfile/index.tsx
@@ -143,7 +143,7 @@ export default function ClaimProfile() {
           ) : (
             <div className="flex flex-col gap-3">
               <p className="text-sm text-rope-500 font-medium">
-                {results.length} perfil{results.length !== 1 ? 'is' : ''} encontrado{results.length !== 1 ? 's' : ''}. Selecione o seu:
+                {results.length !== 1 ? `${results.length} perfis encontrados` : '1 perfil encontrado'}. Selecione o seu:
               </p>
               {results.map(({ profile }) => (
                 <Card key={profile.id}>

--- a/src/screens/competitor/portal/CompetitionResults/index.tsx
+++ b/src/screens/competitor/portal/CompetitionResults/index.tsx
@@ -1,0 +1,135 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { getCompetition, Competition } from '../../../../services/firebase/competitions';
+import { buildBestQualifierScorePerDuo } from '../../../../core/logic/scoring';
+import { aggregateFinals } from '../../../../core/logic/finals';
+import { Card } from '../../../../components/ui/Card';
+import { GroupBadge } from '../../../../components/ui/Badge';
+import { Spinner } from '../../../../components/ui/Spinner';
+import { EmptyState } from '../../../../components/ui/EmptyState';
+import { Button } from '../../../../components/ui/Button';
+
+export default function CompetitionResults() {
+  const { competitionId } = useParams<{ competitionId: string }>();
+  const navigate = useNavigate();
+  const [competition, setCompetition] = useState<Competition | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!competitionId) return;
+    setLoading(true);
+    getCompetition(competitionId)
+      .then(setCompetition)
+      .catch(() => setCompetition(null))
+      .finally(() => setLoading(false));
+  }, [competitionId]);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-16">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (!competition) {
+    return (
+      <EmptyState
+        icon="📊"
+        title="Competição não encontrada"
+        description="Verifique o link e tente novamente."
+        action={<Button variant="outline" onClick={() => navigate('/portal')}>Voltar ao portal</Button>}
+      />
+    );
+  }
+
+  if (competition.status !== 'finished') {
+    return (
+      <div className="flex flex-col gap-6">
+        <Button variant="outline" size="sm" onClick={() => navigate(-1)} className="self-start">
+          ← Voltar
+        </Button>
+        <EmptyState
+          icon="⏳"
+          title="Resultados ainda não disponíveis"
+          description={`A competição "${competition.name}" ainda não foi encerrada.`}
+        />
+      </div>
+    );
+  }
+
+  const duoGroupById = new Map(competition.duos.map((d) => [d.id, d.group]));
+  const bestQual = buildBestQualifierScorePerDuo(competition.qualifierResults, duoGroupById);
+  const aggregates = aggregateFinals(bestQual, competition.finalResults);
+
+  const results1D = aggregates.filter((a) => a.group === '1D');
+  const results2D = aggregates.filter((a) => a.group === '2D');
+
+  function getDuoLabel(duoId: string) {
+    const duo = competition!.duos.find((d) => d.id === duoId);
+    if (duo?.label) return duo.label;
+    const r1 = competition!.competitors.find((c) => c.id === duo?.riderOneId);
+    const r2 = competition!.competitors.find((c) => c.id === duo?.riderTwoId);
+    return `${r1?.name ?? '?'} & ${r2?.name ?? '?'}`;
+  }
+
+  const medal = (pos: number) => (pos === 1 ? '🥇' : pos === 2 ? '🥈' : pos === 3 ? '🥉' : '');
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center gap-3">
+        <Button variant="outline" size="sm" onClick={() => navigate(-1)}>
+          ← Voltar
+        </Button>
+        <div>
+          <h2 className="font-serif font-bold text-rope-800 text-xl">{competition.name}</h2>
+          <p className="text-rope-400 text-sm">Resultado final</p>
+        </div>
+      </div>
+
+      {[
+        { label: 'Categoria 1D', data: results1D },
+        { label: 'Categoria 2D', data: results2D },
+      ].map(({ label, data }) =>
+        data.length === 0 ? null : (
+          <Card key={label} title={label} noPadding>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="bg-dust-50 border-b border-dust-200">
+                  <tr>
+                    <th className="px-4 py-2.5 text-center text-xs font-semibold text-rope-500 w-10">#</th>
+                    <th className="px-4 py-2.5 text-left text-xs font-semibold text-rope-500">Dupla</th>
+                    <th className="px-4 py-2.5 text-center text-xs font-semibold text-rope-500">Grupo</th>
+                    <th className="px-4 py-2.5 text-center text-xs font-semibold text-rope-500">Bois</th>
+                    <th className="px-4 py-2.5 text-center text-xs font-semibold text-rope-500">Tempo</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-dust-100">
+                  {data.map((row, idx) => (
+                    <tr key={row.duoId} className="hover:bg-dust-50">
+                      <td className="px-4 py-2.5 text-center text-xs text-rope-400 font-mono">
+                        {medal(idx + 1) || `${idx + 1}º`}
+                      </td>
+                      <td className="px-4 py-2.5 font-medium text-rope-800">
+                        {getDuoLabel(row.duoId)}
+                      </td>
+                      <td className="px-4 py-2.5 text-center">
+                        <GroupBadge group={row.group} />
+                      </td>
+                      <td className="px-4 py-2.5 text-center font-semibold text-rope-700">
+                        {row.totalCattle}
+                      </td>
+                      <td className="px-4 py-2.5 text-center text-rope-600">
+                        {row.totalTimeSeconds.toFixed(2)}s
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </Card>
+        )
+      )}
+    </div>
+  );
+}

--- a/src/screens/competitor/portal/Dashboard/index.tsx
+++ b/src/screens/competitor/portal/Dashboard/index.tsx
@@ -1,0 +1,199 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate, Outlet, useLocation, NavLink } from 'react-router-dom';
+import { CompetitorProfile } from '../../../../core/models/CompetitorProfile';
+import {
+  getCompetitorProfile,
+} from '../../../../services/firebase/competitorProfiles';
+import {
+  getCompetitorHistory,
+  CompetitionHistoryEntry,
+} from '../../../../services/firebase/competitorHistory';
+import { useAuth } from '../../../../context/AuthContext';
+import { signOut } from '../../../../services/firebase/auth';
+import { Button } from '../../../../components/ui/Button';
+import { Spinner } from '../../../../components/ui/Spinner';
+import ClaimProfile from '../ClaimProfile';
+
+const NAV_ITEMS = [
+  { to: '/portal', label: 'Minhas Competições', icon: '🏟️', end: true },
+  { to: '/portal/passes', label: 'Minhas Passadas', icon: '📋', end: false },
+];
+
+export default function PortalDashboard() {
+  const { user, competitorProfileId, isLoading: authLoading } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const [profile, setProfile] = useState<CompetitorProfile | null>(null);
+  const [history, setHistory] = useState<CompetitionHistoryEntry[]>([]);
+  const [loadingProfile, setLoadingProfile] = useState(false);
+  const [loadingHistory, setLoadingHistory] = useState(false);
+
+  useEffect(() => {
+    if (!competitorProfileId) {
+      setProfile(null);
+      setHistory([]);
+      return;
+    }
+    setLoadingProfile(true);
+    getCompetitorProfile(competitorProfileId)
+      .then((p) => {
+        setProfile(p);
+        if (p) {
+          setLoadingHistory(true);
+          return getCompetitorHistory(p.id);
+        }
+        return [];
+      })
+      .then(setHistory)
+      .catch(() => {})
+      .finally(() => {
+        setLoadingProfile(false);
+        setLoadingHistory(false);
+      });
+  }, [competitorProfileId]);
+
+  async function handleLogout() {
+    await signOut();
+    navigate('/login');
+  }
+
+  if (authLoading || loadingProfile) {
+    return (
+      <div className="min-h-screen bg-dust-100 flex items-center justify-center">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  // Pass history down via context-like prop to sub-pages through Outlet context
+  const isClaimRoute = location.pathname === '/portal/claim';
+  const isResultsRoute = location.pathname.startsWith('/portal/results/');
+
+  return (
+    <div className="min-h-screen bg-dust-100 flex flex-col">
+      {/* Header */}
+      <header className="bg-saddle-800 text-white px-6 py-4 flex items-center justify-between shadow-md">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => navigate('/')}
+            className="text-saddle-300 hover:text-white transition-colors p-1"
+            title="Voltar ao painel do organizador"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+          </button>
+          <div>
+            <h1 className="font-serif font-bold text-lg">Portal do Competidor</h1>
+            {profile && (
+              <p className="text-saddle-300 text-xs">{profile.displayName}</p>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center gap-3">
+          <span className="text-saddle-200 text-sm hidden sm:block">
+            {user?.displayName ?? user?.email}
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleLogout}
+            className="text-saddle-200 hover:text-white hover:bg-saddle-700"
+          >
+            Sair
+          </Button>
+        </div>
+      </header>
+
+      {/* No profile — show claim flow */}
+      {!competitorProfileId && !isClaimRoute && (
+        <main className="max-w-2xl mx-auto px-4 py-12 w-full">
+          <div className="text-center mb-8">
+            <div className="text-5xl mb-4">🔗</div>
+            <h2 className="font-serif font-bold text-rope-800 text-2xl mb-2">
+              Vincule seu perfil de competidor
+            </h2>
+            <p className="text-rope-400">
+              Para acessar seu histórico, você precisa vincular sua conta a um perfil de competidor.
+            </p>
+          </div>
+          <ClaimProfile />
+        </main>
+      )}
+
+      {/* No profile — claim sub-route */}
+      {!competitorProfileId && isClaimRoute && (
+        <main className="max-w-2xl mx-auto px-4 py-8 w-full">
+          <ClaimProfile />
+        </main>
+      )}
+
+      {/* Has profile */}
+      {competitorProfileId && (
+        <>
+          {/* Stats bar */}
+          {!isResultsRoute && !isClaimRoute && (
+            <div className="bg-white border-b border-dust-300">
+              <div className="max-w-5xl mx-auto px-4 py-4 flex gap-6 text-sm">
+                <div>
+                  <span className="font-bold text-saddle-700 text-xl">{history.length}</span>
+                  <span className="text-rope-400 ml-1.5">competição{history.length !== 1 ? 'ões' : ''}</span>
+                </div>
+                <div>
+                  <span className="font-bold text-saddle-700 text-xl">
+                    {history.flatMap((h) => h.passes).length}
+                  </span>
+                  <span className="text-rope-400 ml-1.5">passada{history.flatMap((h) => h.passes).length !== 1 ? 's' : ''}</span>
+                </div>
+                <div>
+                  <span className="font-bold text-saddle-700 text-xl">
+                    {history.flatMap((h) => h.passes).reduce((s, p) => s + p.cattleCount, 0)}
+                  </span>
+                  <span className="text-rope-400 ml-1.5">bois totais</span>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Nav tabs */}
+          {!isResultsRoute && !isClaimRoute && (
+            <nav className="bg-white border-b border-dust-300">
+              <div className="max-w-5xl mx-auto px-4 flex gap-0">
+                {NAV_ITEMS.map((item) => (
+                  <NavLink
+                    key={item.to}
+                    to={item.to}
+                    end={item.end}
+                    className={({ isActive }) =>
+                      [
+                        'flex items-center gap-2 px-4 py-3 text-sm font-medium border-b-2 transition-colors',
+                        isActive
+                          ? 'border-saddle-600 text-saddle-700'
+                          : 'border-transparent text-rope-400 hover:text-rope-700 hover:border-dust-400',
+                      ].join(' ')
+                    }
+                  >
+                    <span>{item.icon}</span>
+                    <span>{item.label}</span>
+                  </NavLink>
+                ))}
+              </div>
+            </nav>
+          )}
+
+          {/* Content */}
+          <main className="max-w-5xl mx-auto w-full px-4 py-6">
+            {loadingHistory ? (
+              <div className="flex justify-center py-16">
+                <Spinner size="lg" />
+              </div>
+            ) : (
+              <Outlet context={{ history, profile }} />
+            )}
+          </main>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/screens/competitor/portal/Dashboard/index.tsx
+++ b/src/screens/competitor/portal/Dashboard/index.tsx
@@ -12,7 +12,6 @@ import { useAuth } from '../../../../context/AuthContext';
 import { signOut } from '../../../../services/firebase/auth';
 import { Button } from '../../../../components/ui/Button';
 import { Spinner } from '../../../../components/ui/Spinner';
-import ClaimProfile from '../ClaimProfile';
 
 const NAV_ITEMS = [
   { to: '/portal', label: 'Minhas Competições', icon: '🏟️', end: true },
@@ -106,45 +105,49 @@ export default function PortalDashboard() {
         </div>
       </header>
 
-      {/* No profile — show claim flow */}
+      {/* No profile + not on /portal/claim → CTA to claim */}
       {!competitorProfileId && !isClaimRoute && (
-        <main className="max-w-2xl mx-auto px-4 py-12 w-full">
-          <div className="text-center mb-8">
-            <div className="text-5xl mb-4">🔗</div>
-            <h2 className="font-serif font-bold text-rope-800 text-2xl mb-2">
-              Vincule seu perfil de competidor
-            </h2>
-            <p className="text-rope-400">
-              Para acessar seu histórico, você precisa vincular sua conta a um perfil de competidor.
-            </p>
-          </div>
-          <ClaimProfile />
+        <main className="max-w-2xl mx-auto px-4 py-12 w-full text-center">
+          <div className="text-5xl mb-4">🔗</div>
+          <h2 className="font-serif font-bold text-rope-800 text-2xl mb-2">
+            Vincule seu perfil de competidor
+          </h2>
+          <p className="text-rope-400 mb-6">
+            Para acessar seu histórico, vincule sua conta a um perfil de competidor.
+          </p>
+          <Button onClick={() => navigate('/portal/claim')}>
+            Vincular perfil
+          </Button>
         </main>
       )}
 
-      {/* No profile — claim sub-route */}
-      {!competitorProfileId && isClaimRoute && (
+      {/* /portal/claim — render via Outlet (regardless of profile status) */}
+      {isClaimRoute && (
         <main className="max-w-2xl mx-auto px-4 py-8 w-full">
-          <ClaimProfile />
+          <Outlet context={{ history, profile }} />
         </main>
       )}
 
-      {/* Has profile */}
-      {competitorProfileId && (
+      {/* Has profile + not on claim route */}
+      {competitorProfileId && !isClaimRoute && (
         <>
           {/* Stats bar */}
-          {!isResultsRoute && !isClaimRoute && (
+          {!isResultsRoute && (
             <div className="bg-white border-b border-dust-300">
               <div className="max-w-5xl mx-auto px-4 py-4 flex gap-6 text-sm">
                 <div>
                   <span className="font-bold text-saddle-700 text-xl">{history.length}</span>
-                  <span className="text-rope-400 ml-1.5">competição{history.length !== 1 ? 'ões' : ''}</span>
+                  <span className="text-rope-400 ml-1.5">
+                    {history.length !== 1 ? 'competições' : 'competição'}
+                  </span>
                 </div>
                 <div>
                   <span className="font-bold text-saddle-700 text-xl">
                     {history.flatMap((h) => h.passes).length}
                   </span>
-                  <span className="text-rope-400 ml-1.5">passada{history.flatMap((h) => h.passes).length !== 1 ? 's' : ''}</span>
+                  <span className="text-rope-400 ml-1.5">
+                    passada{history.flatMap((h) => h.passes).length !== 1 ? 's' : ''}
+                  </span>
                 </div>
                 <div>
                   <span className="font-bold text-saddle-700 text-xl">
@@ -157,7 +160,7 @@ export default function PortalDashboard() {
           )}
 
           {/* Nav tabs */}
-          {!isResultsRoute && !isClaimRoute && (
+          {!isResultsRoute && (
             <nav className="bg-white border-b border-dust-300">
               <div className="max-w-5xl mx-auto px-4 flex gap-0">
                 {NAV_ITEMS.map((item) => (

--- a/src/screens/competitor/portal/MyCompetitions/index.tsx
+++ b/src/screens/competitor/portal/MyCompetitions/index.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { CompetitionHistoryEntry } from '../../../../services/firebase/competitorHistory';
+import { Card } from '../../../../components/ui/Card';
+import { EmptyState } from '../../../../components/ui/EmptyState';
+
+const STATUS_LABEL: Record<string, string> = {
+  draft: 'Rascunho',
+  qualifier: 'Qualificatória',
+  final: 'Final',
+  finished: 'Encerrada',
+};
+
+const STATUS_COLOR: Record<string, string> = {
+  draft: 'bg-dust-200 text-rope-500',
+  qualifier: 'bg-blue-100 text-blue-700',
+  final: 'bg-hay-100 text-hay-700',
+  finished: 'bg-green-100 text-green-700',
+};
+
+interface Props {
+  history: CompetitionHistoryEntry[];
+}
+
+export default function MyCompetitions({ history }: Props) {
+  if (history.length === 0) {
+    return (
+      <EmptyState
+        icon="🏟️"
+        title="Nenhuma competição encontrada"
+        description="Suas competições aparecerão aqui após serem vinculadas ao seu perfil."
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {history.map((entry) => (
+        <CompetitionCard key={entry.competitionId} entry={entry} />
+      ))}
+    </div>
+  );
+}
+
+function CompetitionCard({ entry }: { entry: CompetitionHistoryEntry }) {
+  const date = entry.eventDate
+    ? new Date(entry.eventDate + 'T12:00').toLocaleDateString('pt-BR', {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+      })
+    : null;
+
+  const qualPasses = entry.passes.filter((p) => p.stage === 'Qualifier');
+  const finalPasses = entry.passes.filter((p) => p.stage === 'Final');
+  const totalCattle = entry.passes.reduce((s, p) => s + p.cattleCount, 0);
+
+  return (
+    <Card noPadding>
+      <div className="p-5">
+        <div className="flex items-start justify-between gap-3 mb-3">
+          <div>
+            <h3 className="font-serif font-semibold text-rope-800 text-base">
+              {entry.competitionName}
+            </h3>
+            {entry.location && (
+              <p className="text-rope-400 text-xs mt-0.5">📍 {entry.location}</p>
+            )}
+            {date && <p className="text-rope-400 text-xs mt-0.5">📅 {date}</p>}
+          </div>
+          <span
+            className={[
+              'text-xs px-2.5 py-1 rounded-full font-medium shrink-0',
+              STATUS_COLOR[entry.status] ?? 'bg-dust-200 text-rope-500',
+            ].join(' ')}
+          >
+            {STATUS_LABEL[entry.status] ?? entry.status}
+          </span>
+        </div>
+
+        <div className="flex gap-4 text-xs text-rope-500">
+          <span>🐄 {totalCattle} bois totais</span>
+          <span>📋 {qualPasses.length} qualificatória{qualPasses.length !== 1 ? 's' : ''}</span>
+          {finalPasses.length > 0 && (
+            <span>🏆 {finalPasses.length} final</span>
+          )}
+        </div>
+      </div>
+
+      {entry.status === 'finished' && (
+        <div className="px-5 py-3 border-t border-dust-200 bg-dust-50 rounded-b-xl">
+          <Link
+            to={`/portal/results/${entry.competitionId}`}
+            className="text-sm text-saddle-600 hover:text-saddle-800 font-medium"
+          >
+            Ver resultados →
+          </Link>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/src/screens/competitor/portal/MyCompetitionsPage/index.tsx
+++ b/src/screens/competitor/portal/MyCompetitionsPage/index.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { useOutletContext } from 'react-router-dom';
+import { CompetitionHistoryEntry } from '../../../../services/firebase/competitorHistory';
+import { CompetitorProfile } from '../../../../core/models/CompetitorProfile';
+import MyCompetitions from '../MyCompetitions';
+
+interface OutletCtx {
+  history: CompetitionHistoryEntry[];
+  profile: CompetitorProfile | null;
+}
+
+export default function MyCompetitionsPage() {
+  const { history } = useOutletContext<OutletCtx>();
+  return <MyCompetitions history={history} />;
+}

--- a/src/screens/competitor/portal/MyPasses/index.tsx
+++ b/src/screens/competitor/portal/MyPasses/index.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { CompetitionHistoryEntry } from '../../../../services/firebase/competitorHistory';
+import { Card } from '../../../../components/ui/Card';
+import { EmptyState } from '../../../../components/ui/EmptyState';
+import { GroupBadge } from '../../../../components/ui/Badge';
+
+interface Props {
+  history: CompetitionHistoryEntry[];
+}
+
+export default function MyPasses({ history }: Props) {
+  const allPasses = history.flatMap((h) =>
+    h.passes.map((p) => ({ ...p, competitionName: h.competitionName }))
+  );
+
+  if (allPasses.length === 0) {
+    return (
+      <EmptyState
+        icon="📋"
+        title="Nenhuma passada registrada"
+        description="Suas passadas aparecerão aqui após serem vinculadas ao seu perfil."
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      {history.map((entry) => {
+        if (entry.passes.length === 0) return null;
+        return <CompetitionPassBlock key={entry.competitionId} entry={entry} />;
+      })}
+    </div>
+  );
+}
+
+function formatTime(seconds: number, isSAT: boolean) {
+  if (isSAT) return 'SAT';
+  return `${seconds.toFixed(2)}s`;
+}
+
+function CompetitionPassBlock({ entry }: { entry: CompetitionHistoryEntry }) {
+  const date = entry.eventDate
+    ? new Date(entry.eventDate + 'T12:00').toLocaleDateString('pt-BR', {
+        day: '2-digit',
+        month: 'short',
+        year: 'numeric',
+      })
+    : null;
+
+  return (
+    <Card
+      title={entry.competitionName}
+      subtitle={[entry.location, date].filter(Boolean).join(' · ')}
+      noPadding
+    >
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead className="bg-dust-50 border-b border-dust-200">
+            <tr>
+              <th className="px-4 py-2.5 text-left text-xs font-semibold text-rope-500">Etapa</th>
+              <th className="px-4 py-2.5 text-left text-xs font-semibold text-rope-500">Parceiro</th>
+              <th className="px-4 py-2.5 text-center text-xs font-semibold text-rope-500">Grupo</th>
+              <th className="px-4 py-2.5 text-center text-xs font-semibold text-rope-500">B.Cant.</th>
+              <th className="px-4 py-2.5 text-center text-xs font-semibold text-rope-500">Bois</th>
+              <th className="px-4 py-2.5 text-center text-xs font-semibold text-rope-500">Tempo</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-dust-100">
+            {entry.passes.map((pass, i) => (
+              <tr
+                key={`${pass.duoId}-${i}`}
+                className={pass.isSAT ? 'bg-brand-50' : 'hover:bg-dust-50'}
+              >
+                <td className="px-4 py-2.5">
+                  <span
+                    className={[
+                      'text-xs px-1.5 py-0.5 rounded font-medium',
+                      pass.stage === 'Qualifier'
+                        ? 'bg-blue-50 text-blue-700'
+                        : 'bg-hay-50 text-hay-700',
+                    ].join(' ')}
+                  >
+                    {pass.stage === 'Qualifier' ? 'Qualificatória' : 'Final'}
+                  </span>
+                </td>
+                <td className="px-4 py-2.5 font-medium text-rope-800">{pass.partnerName}</td>
+                <td className="px-4 py-2.5 text-center">
+                  <GroupBadge group={pass.group as '1D' | '2D'} />
+                </td>
+                <td className="px-4 py-2.5 text-center text-rope-500">
+                  {pass.calledCattle ?? '—'}
+                </td>
+                <td className="px-4 py-2.5 text-center font-semibold text-rope-700">
+                  {pass.cattleCount}
+                </td>
+                <td className="px-4 py-2.5 text-center text-rope-600">
+                  {formatTime(pass.timeSeconds, pass.isSAT)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Card>
+  );
+}

--- a/src/screens/competitor/portal/MyPassesPage/index.tsx
+++ b/src/screens/competitor/portal/MyPassesPage/index.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { useOutletContext } from 'react-router-dom';
+import { CompetitionHistoryEntry } from '../../../../services/firebase/competitorHistory';
+import { CompetitorProfile } from '../../../../core/models/CompetitorProfile';
+import MyPasses from '../MyPasses';
+
+interface OutletCtx {
+  history: CompetitionHistoryEntry[];
+  profile: CompetitorProfile | null;
+}
+
+export default function MyPassesPage() {
+  const { history } = useOutletContext<OutletCtx>();
+  return <MyPasses history={history} />;
+}

--- a/src/services/competitorLinking.ts
+++ b/src/services/competitorLinking.ts
@@ -1,0 +1,47 @@
+import { Competitor } from '../core/models/Competidor';
+import {
+  searchProfilesByNormalizedName,
+  createCompetitorProfile,
+} from './firebase/competitorProfiles';
+import {
+  createCompetitorLink,
+  getLinkForCompetitor,
+} from './firebase/competitorLinks';
+
+// Creates or reuses a CompetitorProfile and links it to the competition entry.
+// Runs silently — never throws; errors are swallowed to protect organizer flow.
+export async function tryAutoLinkCompetitor(
+  competitor: Competitor,
+  competitionId: string
+): Promise<void> {
+  try {
+    const existing = await getLinkForCompetitor(competitionId, competitor.id);
+    if (existing) return;
+
+    const exactMatches = await searchProfilesByNormalizedName(competitor.name);
+    let profileId: string;
+
+    if (exactMatches.length > 0) {
+      profileId = exactMatches[0].id;
+      await createCompetitorLink({
+        profileId,
+        competitionId,
+        competitorId: competitor.id,
+        matchType: 'auto_exact',
+        confidence: 1.0,
+      });
+    } else {
+      const newProfile = await createCompetitorProfile(competitor.name);
+      profileId = newProfile.id;
+      await createCompetitorLink({
+        profileId,
+        competitionId,
+        competitorId: competitor.id,
+        matchType: 'auto_exact',
+        confidence: 1.0,
+      });
+    }
+  } catch {
+    // Intentionally silent — auto-linking is best-effort
+  }
+}

--- a/src/services/firebase/competitorHistory.ts
+++ b/src/services/firebase/competitorHistory.ts
@@ -1,0 +1,89 @@
+import { getLinksByProfileId } from './competitorLinks';
+import { getCompetition } from './competitions';
+
+export interface PassEntry {
+  duoId: string;
+  stage: 'Qualifier' | 'Final';
+  partnerName: string;
+  partnerCategory: string;
+  group: '1D' | '2D';
+  cattleCount: number;
+  timeSeconds: number;
+  isSAT: boolean;
+  calledCattle?: number;
+  passNumber?: number;
+}
+
+export interface CompetitionHistoryEntry {
+  competitionId: string;
+  competitionName: string;
+  location?: string;
+  eventDate?: string;
+  status: string;
+  competitorId: string;
+  passes: PassEntry[];
+}
+
+export async function getCompetitorHistory(
+  profileId: string
+): Promise<CompetitionHistoryEntry[]> {
+  const links = await getLinksByProfileId(profileId);
+  if (links.length === 0) return [];
+
+  const entries: (CompetitionHistoryEntry | null)[] = await Promise.all(
+    links.map(async (link) => {
+      const competition = await getCompetition(link.competitionId);
+      if (!competition) return null;
+
+      const { competitorId } = link;
+      const myDuos = competition.duos.filter(
+        (d) => d.riderOneId === competitorId || d.riderTwoId === competitorId
+      );
+      const myDuoIds = new Set(myDuos.map((d) => d.id));
+
+      const allResults = [
+        ...competition.qualifierResults,
+        ...competition.finalResults,
+      ];
+      const myResults = allResults.filter((r) => myDuoIds.has(r.duoId));
+
+      const passes: PassEntry[] = myResults.map((r) => {
+        const duo = myDuos.find((d) => d.id === r.duoId);
+        const partnerId =
+          duo?.riderOneId === competitorId ? duo?.riderTwoId : duo?.riderOneId;
+        const partner = competition.competitors.find((c) => c.id === partnerId);
+        return {
+          duoId: r.duoId,
+          stage: r.stage,
+          partnerName: partner?.name ?? '?',
+          partnerCategory: partner?.category ?? 'Open',
+          group: (duo?.group ?? '1D') as '1D' | '2D',
+          cattleCount: r.cattleCount,
+          timeSeconds: r.timeSeconds,
+          isSAT: r.isSAT ?? false,
+          calledCattle: r.calledCattle,
+          passNumber: duo?.passNumber,
+        };
+      });
+
+      const entry: CompetitionHistoryEntry = {
+        competitionId: link.competitionId,
+        competitionName: competition.name,
+        location: competition.location,
+        eventDate: competition.eventDate,
+        status: competition.status,
+        competitorId,
+        passes,
+      };
+      return entry;
+    })
+  );
+
+  return entries
+    .filter((e): e is CompetitionHistoryEntry => e !== null)
+    .sort((a, b) => {
+      const da = a.eventDate ?? '';
+      const db = b.eventDate ?? '';
+      return db.localeCompare(da);
+    });
+}

--- a/src/services/firebase/competitorLinks.ts
+++ b/src/services/firebase/competitorLinks.ts
@@ -1,0 +1,60 @@
+import {
+  collection,
+  addDoc,
+  getDocs,
+  query,
+  where,
+  serverTimestamp,
+  Timestamp,
+} from 'firebase/firestore';
+import { db } from '../../firebase';
+import { CompetitorLink } from '../../core/models/CompetitorProfile';
+
+function toLink(id: string, data: any): CompetitorLink {
+  return {
+    id,
+    profileId: data.profileId,
+    competitionId: data.competitionId,
+    competitorId: data.competitorId,
+    matchType: data.matchType,
+    confidence: data.confidence ?? 1.0,
+    createdAt:
+      data.createdAt instanceof Timestamp
+        ? data.createdAt.toDate().toISOString()
+        : data.createdAt ?? new Date().toISOString(),
+    createdBy: data.createdBy,
+  };
+}
+
+export async function createCompetitorLink(
+  link: Omit<CompetitorLink, 'id' | 'createdAt'>
+): Promise<CompetitorLink> {
+  const ref = await addDoc(collection(db, 'competitorLinks'), {
+    ...link,
+    createdAt: serverTimestamp(),
+  });
+  return toLink(ref.id, { ...link, createdAt: new Date().toISOString() });
+}
+
+export async function getLinksByProfileId(profileId: string): Promise<CompetitorLink[]> {
+  const q = query(
+    collection(db, 'competitorLinks'),
+    where('profileId', '==', profileId)
+  );
+  const snap = await getDocs(q);
+  return snap.docs.map((d) => toLink(d.id, d.data()));
+}
+
+export async function getLinkForCompetitor(
+  competitionId: string,
+  competitorId: string
+): Promise<CompetitorLink | null> {
+  const q = query(
+    collection(db, 'competitorLinks'),
+    where('competitionId', '==', competitionId),
+    where('competitorId', '==', competitorId)
+  );
+  const snap = await getDocs(q);
+  if (snap.empty) return null;
+  return toLink(snap.docs[0].id, snap.docs[0].data());
+}

--- a/src/services/firebase/competitorLinks.ts
+++ b/src/services/firebase/competitorLinks.ts
@@ -52,7 +52,8 @@ export async function getLinkForCompetitor(
   const q = query(
     collection(db, 'competitorLinks'),
     where('competitionId', '==', competitionId),
-    where('competitorId', '==', competitorId)
+    where('competitorId', '==', competitorId),
+    limit(1)
   );
   const snap = await getDocs(q);
   if (snap.empty) return null;

--- a/src/services/firebase/competitorLinks.ts
+++ b/src/services/firebase/competitorLinks.ts
@@ -4,6 +4,7 @@ import {
   getDocs,
   query,
   where,
+  limit,
   serverTimestamp,
   Timestamp,
 } from 'firebase/firestore';

--- a/src/services/firebase/competitorProfiles.ts
+++ b/src/services/firebase/competitorProfiles.ts
@@ -2,12 +2,12 @@ import {
   collection,
   doc,
   addDoc,
-  updateDoc,
-  getDoc,
   getDocs,
+  getDoc,
   query,
   where,
   limit,
+  runTransaction,
   serverTimestamp,
   Timestamp,
 } from 'firebase/firestore';
@@ -47,7 +47,11 @@ export async function getCompetitorProfile(id: string): Promise<CompetitorProfil
 }
 
 export async function getProfileByUserId(userId: string): Promise<CompetitorProfile | null> {
-  const q = query(collection(db, 'competitorProfiles'), where('userId', '==', userId));
+  const q = query(
+    collection(db, 'competitorProfiles'),
+    where('userId', '==', userId),
+    limit(1)
+  );
   const snap = await getDocs(q);
   if (snap.empty) return null;
   return toProfile(snap.docs[0].id, snap.docs[0].data());
@@ -74,7 +78,7 @@ export async function searchProfilesForUser(
   const q = query(
     collection(db, 'competitorProfiles'),
     where('normalizedName', '>=', normalized),
-    where('normalizedName', '<=', normalized + ''),
+    where('normalizedName', '<=', normalized + '\uf8ff'),
     limit(50)
   );
   const snap = await getDocs(q);
@@ -131,19 +135,33 @@ export async function createCompetitorProfile(
   };
 }
 
+// Atomically claims a profile: verifies it is still unclaimed, then updates
+// both the profile and the user doc in a single transaction to prevent races.
 export async function claimCompetitorProfile(
   profileId: string,
   userId: string,
   email: string
 ): Promise<void> {
-  await updateDoc(doc(db, 'competitorProfiles', profileId), {
-    userId,
-    email,
-    status: 'claimed',
-    claimedAt: serverTimestamp(),
-    updatedAt: serverTimestamp(),
-  });
-  await updateDoc(doc(db, 'users', userId), {
-    competitorProfileId: profileId,
+  const profileRef = doc(db, 'competitorProfiles', profileId);
+  const userRef = doc(db, 'users', userId);
+
+  await runTransaction(db, async (tx) => {
+    const profileSnap = await tx.get(profileRef);
+    if (!profileSnap.exists()) throw new Error('Perfil não encontrado.');
+
+    const data = profileSnap.data();
+    if (data.status === 'claimed' && data.userId !== userId) {
+      throw new Error('Este perfil já foi reivindicado por outro usuário.');
+    }
+
+    tx.update(profileRef, {
+      userId,
+      email,
+      status: 'claimed',
+      claimedAt: serverTimestamp(),
+      updatedAt: serverTimestamp(),
+    });
+
+    tx.update(userRef, { competitorProfileId: profileId });
   });
 }

--- a/src/services/firebase/competitorProfiles.ts
+++ b/src/services/firebase/competitorProfiles.ts
@@ -1,0 +1,149 @@
+import {
+  collection,
+  doc,
+  addDoc,
+  updateDoc,
+  getDoc,
+  getDocs,
+  query,
+  where,
+  limit,
+  serverTimestamp,
+  Timestamp,
+} from 'firebase/firestore';
+import { db } from '../../firebase';
+import { CompetitorProfile } from '../../core/models/CompetitorProfile';
+import { normalizeName, nameSimilarity } from '../../utils/nameNormalization';
+
+function toProfile(id: string, data: any): CompetitorProfile {
+  return {
+    id,
+    displayName: data.displayName ?? '',
+    aliases: data.aliases ?? [],
+    normalizedName: data.normalizedName ?? '',
+    userId: data.userId ?? undefined,
+    email: data.email ?? undefined,
+    status: data.status ?? 'unclaimed',
+    mergedIntoProfileId: data.mergedIntoProfileId ?? undefined,
+    createdAt:
+      data.createdAt instanceof Timestamp
+        ? data.createdAt.toDate().toISOString()
+        : data.createdAt ?? new Date().toISOString(),
+    updatedAt:
+      data.updatedAt instanceof Timestamp
+        ? data.updatedAt.toDate().toISOString()
+        : data.updatedAt ?? new Date().toISOString(),
+    claimedAt:
+      data.claimedAt instanceof Timestamp
+        ? data.claimedAt.toDate().toISOString()
+        : data.claimedAt ?? undefined,
+  };
+}
+
+export async function getCompetitorProfile(id: string): Promise<CompetitorProfile | null> {
+  const snap = await getDoc(doc(db, 'competitorProfiles', id));
+  if (!snap.exists()) return null;
+  return toProfile(snap.id, snap.data());
+}
+
+export async function getProfileByUserId(userId: string): Promise<CompetitorProfile | null> {
+  const q = query(collection(db, 'competitorProfiles'), where('userId', '==', userId));
+  const snap = await getDocs(q);
+  if (snap.empty) return null;
+  return toProfile(snap.docs[0].id, snap.docs[0].data());
+}
+
+// Exact match by normalizedName — used for auto-linking (cheap, no fuzzy)
+export async function searchProfilesByNormalizedName(name: string): Promise<CompetitorProfile[]> {
+  const normalized = normalizeName(name);
+  const q = query(
+    collection(db, 'competitorProfiles'),
+    where('normalizedName', '==', normalized)
+  );
+  const snap = await getDocs(q);
+  return snap.docs.map((d) => toProfile(d.id, d.data()));
+}
+
+// Prefix + client-side fuzzy — used for user-facing search
+export async function searchProfilesForUser(
+  queryStr: string
+): Promise<Array<{ profile: CompetitorProfile; score: number }>> {
+  if (!queryStr.trim()) return [];
+  const normalized = normalizeName(queryStr);
+
+  const q = query(
+    collection(db, 'competitorProfiles'),
+    where('normalizedName', '>=', normalized),
+    where('normalizedName', '<=', normalized + ''),
+    limit(50)
+  );
+  const snap = await getDocs(q);
+  const profiles = snap.docs.map((d) => toProfile(d.id, d.data()));
+
+  return profiles
+    .filter((p) => p.status !== 'merged')
+    .map((p) => {
+      const score = Math.max(
+        nameSimilarity(queryStr, p.displayName),
+        ...p.aliases.map((a) => nameSimilarity(queryStr, a)),
+        0
+      );
+      return { profile: p, score };
+    })
+    .filter((r) => r.score >= 0.4)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 20);
+}
+
+export async function createCompetitorProfile(
+  name: string,
+  userId?: string,
+  email?: string
+): Promise<CompetitorProfile> {
+  const normalized = normalizeName(name);
+  const now = new Date().toISOString();
+  const payload: Record<string, any> = {
+    displayName: name,
+    aliases: [],
+    normalizedName: normalized,
+    status: userId ? 'claimed' : 'unclaimed',
+    createdAt: serverTimestamp(),
+    updatedAt: serverTimestamp(),
+  };
+  if (userId) {
+    payload.userId = userId;
+    payload.claimedAt = serverTimestamp();
+  }
+  if (email) payload.email = email;
+
+  const ref = await addDoc(collection(db, 'competitorProfiles'), payload);
+  return {
+    id: ref.id,
+    displayName: name,
+    aliases: [],
+    normalizedName: normalized,
+    userId,
+    email,
+    status: userId ? 'claimed' : 'unclaimed',
+    createdAt: now,
+    updatedAt: now,
+    claimedAt: userId ? now : undefined,
+  };
+}
+
+export async function claimCompetitorProfile(
+  profileId: string,
+  userId: string,
+  email: string
+): Promise<void> {
+  await updateDoc(doc(db, 'competitorProfiles', profileId), {
+    userId,
+    email,
+    status: 'claimed',
+    claimedAt: serverTimestamp(),
+    updatedAt: serverTimestamp(),
+  });
+  await updateDoc(doc(db, 'users', userId), {
+    competitorProfileId: profileId,
+  });
+}

--- a/src/utils/nameNormalization.ts
+++ b/src/utils/nameNormalization.ts
@@ -1,0 +1,35 @@
+export function normalizeName(name: string): string {
+  return name
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9\s]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function levenshtein(a: string, b: string): number {
+  const m = a.length;
+  const n = b.length;
+  const dp: number[][] = Array.from({ length: m + 1 }, (_, i) =>
+    Array.from({ length: n + 1 }, (_, j) => (i === 0 ? j : j === 0 ? i : 0))
+  );
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i][j] =
+        a[i - 1] === b[j - 1]
+          ? dp[i - 1][j - 1]
+          : 1 + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1]);
+    }
+  }
+  return dp[m][n];
+}
+
+export function nameSimilarity(a: string, b: string): number {
+  const na = normalizeName(a);
+  const nb = normalizeName(b);
+  if (na === nb) return 1.0;
+  const maxLen = Math.max(na.length, nb.length);
+  if (maxLen === 0) return 1.0;
+  return 1 - levenshtein(na, nb) / maxLen;
+}


### PR DESCRIPTION
- Add CompetitorProfile and CompetitorLink entities (Firestore collections)
- Implement auto-linking: when organizer adds a competitor, a profile is
  created/matched automatically by normalized name (fire-and-forget)
- Add competitor portal with public search, public profile view,
  and authenticated dashboard (My Competitions, My Passes, Results)
- Add claim flow: authenticated users can claim an unclaimed profile
  or create a new one, linking their Firebase account to their competitor
  history across all competitions
- Update AuthContext to expose competitorProfileId and refreshUserDoc()
- Add "Meu Portal" link in organizer dashboard header

https://claude.ai/code/session_016bKgrY8WhtmW9aNDrPiNaz