### PR TITLE
fix: status progression, read-only finished competitions, and athlete save logging

### DIFF
--- a/src/components/layout/CompetitionLayout.tsx
+++ b/src/components/layout/CompetitionLayout.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Outlet, useNavigate, useParams, NavLink } from 'react-router-dom';
+import { Outlet, useNavigate, useParams, NavLink, Navigate, useLocation } from 'react-router-dom';
 import { useCompetition } from '../../context/CompetitionContext';
 import { useResults } from '../../context/ResultContext';
 import { getCompetition } from '../../services/firebase/competitions';
@@ -22,6 +22,7 @@ export function CompetitionLayout() {
   const { initializeFromCompetition } = useResults();
   const { user } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
 
   useEffect(() => {
     if (!id || !user) return;
@@ -54,6 +55,12 @@ export function CompetitionLayout() {
         <Spinner size="lg" />
       </div>
     );
+  }
+
+  const isFinished = competition.status === 'finished';
+  const isOnResultsTab = location.pathname.endsWith('/final-results');
+  if (isFinished && !isOnResultsTab) {
+    return <Navigate to={`/competition/${id}/final-results`} replace />;
   }
 
   return (
@@ -93,24 +100,39 @@ export function CompetitionLayout() {
       {/* Step Navigation */}
       <nav className="bg-white border-b border-dust-300 overflow-x-auto scrollbar-none">
         <div className="flex gap-0 max-w-5xl mx-auto min-w-max px-1 sm:px-4">
-          {steps.map((step) => (
-            <NavLink
-              key={step.key}
-              to={`/competition/${id}/${step.key}`}
-              className={({ isActive }) =>
-                [
-                  'flex flex-col sm:flex-row items-center gap-0.5 sm:gap-1.5 px-3 sm:px-4 py-2 sm:py-3',
-                  'text-xs font-medium whitespace-nowrap border-b-2 transition-colors',
-                  isActive
-                    ? 'border-saddle-600 text-saddle-700'
-                    : 'border-transparent text-rope-400 hover:text-rope-700 hover:border-dust-400',
-                ].join(' ')
-              }
-            >
-              <span className="text-base sm:text-sm">{step.icon}</span>
-              <span className="text-[10px] sm:text-sm leading-tight">{step.label}</span>
-            </NavLink>
-          ))}
+          {steps.map((step) => {
+            const isResultsStep = step.key === 'final-results';
+            if (isFinished && !isResultsStep) {
+              return (
+                <span
+                  key={step.key}
+                  className="flex flex-col sm:flex-row items-center gap-0.5 sm:gap-1.5 px-3 sm:px-4 py-2 sm:py-3 text-xs font-medium whitespace-nowrap border-b-2 border-transparent text-rope-300 cursor-not-allowed select-none"
+                  title="Competição encerrada"
+                >
+                  <span className="text-base sm:text-sm">{step.icon}</span>
+                  <span className="text-[10px] sm:text-sm leading-tight">{step.label}</span>
+                </span>
+              );
+            }
+            return (
+              <NavLink
+                key={step.key}
+                to={`/competition/${id}/${step.key}`}
+                className={({ isActive }) =>
+                  [
+                    'flex flex-col sm:flex-row items-center gap-0.5 sm:gap-1.5 px-3 sm:px-4 py-2 sm:py-3',
+                    'text-xs font-medium whitespace-nowrap border-b-2 transition-colors',
+                    isActive
+                      ? 'border-saddle-600 text-saddle-700'
+                      : 'border-transparent text-rope-400 hover:text-rope-700 hover:border-dust-400',
+                  ].join(' ')
+                }
+              >
+                <span className="text-base sm:text-sm">{step.icon}</span>
+                <span className="text-[10px] sm:text-sm leading-tight">{step.label}</span>
+              </NavLink>
+            );
+          })}
         </div>
       </nav>
 

--- a/src/context/CompetitionContext.tsx
+++ b/src/context/CompetitionContext.tsx
@@ -25,7 +25,7 @@ interface CompetitionContextValue {
   setCompetitors: (c: Competitor[]) => void;
   setDuos: (d: Duo[]) => void;
   setNumRounds: (n: number) => void;
-  advanceStatus: (next: CompetitionStatus) => void;
+  advanceStatus: (next: CompetitionStatus) => Promise<void>;
   persistQualifierResults: (results: PassResult[]) => void;
   persistFinalResults: (results: PassResult[]) => void;
 }
@@ -100,9 +100,22 @@ export function CompetitionProvider({ children }: { children: React.ReactNode })
     save({ numRounds: n });
   }
 
-  function advanceStatus(next: CompetitionStatus) {
-    save({ status: next });
-  }
+  const advanceStatus = useCallback(
+    async (next: CompetitionStatus): Promise<void> => {
+      if (!competition?.id) return;
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      const merged = { ...pendingPatchRef.current, status: next };
+      pendingPatchRef.current = {};
+      setIsSaving(true);
+      try {
+        await updateCompetition(competition.id, merged);
+        setCompetition((prev) => (prev ? { ...prev, ...merged } : prev));
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [competition?.id]
+  );
 
   function persistQualifierResults(results: PassResult[]) {
     save({ qualifierResults: results });

--- a/src/context/CompetitionContext.tsx
+++ b/src/context/CompetitionContext.tsx
@@ -105,10 +105,10 @@ export function CompetitionProvider({ children }: { children: React.ReactNode })
       if (!competition?.id) return;
       if (debounceRef.current) clearTimeout(debounceRef.current);
       const merged = { ...pendingPatchRef.current, status: next };
-      pendingPatchRef.current = {};
       setIsSaving(true);
       try {
         await updateCompetition(competition.id, merged);
+        pendingPatchRef.current = {};
         setCompetition((prev) => (prev ? { ...prev, ...merged } : prev));
       } finally {
         setIsSaving(false);

--- a/src/screens/FinalResults/index.tsx
+++ b/src/screens/FinalResults/index.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useResults } from 'context/ResultContext';
 import { useCompetition } from '../../context/CompetitionContext';
 import { FinalAggregationEntry } from 'core/logic/finals';
+import { useToast } from '../../components/ui/Toast';
 import { exportToExcel } from 'utils/exportExcel';
 import { Button } from '../../components/ui/Button';
 import { Card } from '../../components/ui/Card';
@@ -13,6 +14,7 @@ import { PageHeader } from '../../components/ui/PageHeader';
 export default function FinalResults() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const toast = useToast();
   const { getFinalAggregates, duosMeta } = useResults();
   const { duos: compDuos, competition, advanceStatus } = useCompetition();
   const [isFinishing, setIsFinishing] = useState(false);
@@ -46,10 +48,12 @@ export default function FinalResults() {
     setIsFinishing(true);
     try {
       await advanceStatus('finished');
+      navigate('/');
+    } catch {
+      toast('Erro ao finalizar a competição. Tente novamente.', 'error');
     } finally {
       setIsFinishing(false);
     }
-    navigate('/');
   }
 
   function exportResults() {

--- a/src/screens/FinalResults/index.tsx
+++ b/src/screens/FinalResults/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useResults } from 'context/ResultContext';
 import { useCompetition } from '../../context/CompetitionContext';
@@ -14,7 +14,8 @@ export default function FinalResults() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { getFinalAggregates, duosMeta } = useResults();
-  const { duos: compDuos } = useCompetition();
+  const { duos: compDuos, competition, advanceStatus } = useCompetition();
+  const [isFinishing, setIsFinishing] = useState(false);
 
   const aggregates = getFinalAggregates();
   const metaDuos = duosMeta.length > 0 ? duosMeta : compDuos;
@@ -39,6 +40,16 @@ export default function FinalResults() {
     if (pos === 2) return '🥈';
     if (pos === 3) return '🥉';
     return pos.toString();
+  }
+
+  async function handleFinish() {
+    setIsFinishing(true);
+    try {
+      await advanceStatus('finished');
+    } finally {
+      setIsFinishing(false);
+    }
+    navigate('/');
   }
 
   function exportResults() {
@@ -129,9 +140,15 @@ export default function FinalResults() {
           {rows2D.length > 0 && <ResultTable items={rows2D} label={`Classificação 2D (${rows2D.length} duplas)`} />}
 
           <div className="flex justify-center pt-2">
-            <Button variant="secondary" onClick={() => navigate('/')}>
-              Voltar ao Início
-            </Button>
+            {competition?.status === 'finished' ? (
+              <Button variant="secondary" onClick={() => navigate('/')}>
+                Voltar ao Início
+              </Button>
+            ) : (
+              <Button onClick={handleFinish} loading={isFinishing}>
+                Finalizar Competição
+              </Button>
+            )}
           </div>
         </div>
       )}

--- a/src/screens/Qualifiers/index.tsx
+++ b/src/screens/Qualifiers/index.tsx
@@ -27,7 +27,7 @@ export default function Qualifiers() {
   const [upgradeOpen, setUpgradeOpen] = useState(false);
   const toast = useToast();
   const { addQualifierResult, updateQualifierResult, results, duosMeta } = useResults();
-  const { duos: compDuos } = useCompetition();
+  const { duos: compDuos, advanceStatus } = useCompetition();
 
   const [cattle, setCattle] = useState<number | null>(null);
   const [calledCattle, setCalledCattle] = useState<number | null>(null);
@@ -390,7 +390,14 @@ export default function Qualifiers() {
             )}
 
             {allRegistered && (
-              <Button onClick={() => navigate(`/competition/${id}/final`)} size="lg" fullWidth>
+              <Button
+                onClick={() => {
+                  advanceStatus('final');
+                  navigate(`/competition/${id}/final`);
+                }}
+                size="lg"
+                fullWidth
+              >
                 Ir para a Final →
               </Button>
             )}

--- a/src/screens/Qualifiers/index.tsx
+++ b/src/screens/Qualifiers/index.tsx
@@ -33,6 +33,7 @@ export default function Qualifiers() {
   const [calledCattle, setCalledCattle] = useState<number | null>(null);
   const [timeSeconds, setTimeSeconds] = useState('');
   const [timeError, setTimeError] = useState('');
+  const [isAdvancing, setIsAdvancing] = useState(false);
 
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editCattle, setEditCattle] = useState<number | null>(null);
@@ -171,6 +172,18 @@ export default function Qualifiers() {
       rows: combinedRows,
       fileName: 'Resultados_Qualificatorias',
     });
+  }
+
+  async function handleGoToFinal() {
+    setIsAdvancing(true);
+    try {
+      await advanceStatus('final');
+      navigate(`/competition/${id}/final`);
+    } catch {
+      toast('Erro ao avançar para a Final. Tente novamente.', 'error');
+    } finally {
+      setIsAdvancing(false);
+    }
   }
 
   function RankingTable({ rows, title }: { rows: PartialRow[]; title: string }) {
@@ -390,14 +403,7 @@ export default function Qualifiers() {
             )}
 
             {allRegistered && (
-              <Button
-                onClick={() => {
-                  advanceStatus('final');
-                  navigate(`/competition/${id}/final`);
-                }}
-                size="lg"
-                fullWidth
-              >
+              <Button onClick={handleGoToFinal} loading={isAdvancing} size="lg" fullWidth>
                 Ir para a Final →
               </Button>
             )}

--- a/src/screens/Registration/index.tsx
+++ b/src/screens/Registration/index.tsx
@@ -85,7 +85,8 @@ export default function Registration() {
     if (saveToBase && user?.uid) {
       try {
         await saveAthlete(user.uid, { name: newCompetitor.name, category: newCompetitor.category });
-      } catch {
+      } catch (err) {
+        console.error('[saveAthlete] failed:', err);
         toast('Competidor adicionado, mas falha ao salvar na base', 'warning');
       }
     }


### PR DESCRIPTION
## Summary

- **Status always shows "Rascunho"**: `advanceStatus` now writes to Firestore immediately (bypasses the 1500ms debounce). Clicking "Ir para a Final" in the Qualifiers screen advances status to `final`; clicking "Finalizar Competição" in Final Results advances it to `finished`.
- **"Voltar ao Início" resets data**: Replaced with a "Finalizar Competição" button that `await`s the Firestore write before navigating. If the competition is already `finished` (re-opened later), it shows "Voltar ao Início" instead.
- **Finished competitions are now read-only**: `CompetitionLayout` redirects any `finished` competition straight to the `final-results` tab, and renders all other step tabs as greyed-out/non-clickable.
- **Athlete save error surfaced**: Added `console.error` to the `saveAthlete` catch block so the actual Firebase error (likely a Firestore security rules issue on `users/{uid}/athletes`) is visible in DevTools Console for diagnosis.

## Test plan

- [ ] Create a competition, add competitors, sort duos, run qualifiers
- [ ] Click "Ir para a Final" — Dashboard card should now show **"Final"** instead of "Rascunho"
- [ ] Complete finals, click "Finalizar Competição" — Dashboard card should show **"Encerrada"**
- [ ] Click the finished competition card — should open directly on the Results tab with all other tabs greyed out and non-clickable
- [ ] Check that "Salvar na base de competidores" error details appear in browser DevTools Console

https://claude.ai/code/session_016bKgrY8WhtmW9aNDrPiNaz

---
_Generated by [Claude Code](https://claude.ai/code/session_016bKgrY8WhtmW9aNDrPiNaz)_