### PR TITLE
feat: importar competidores via planilha com seleção de destino

### DIFF
--- a/src/screens/Registration/index.tsx
+++ b/src/screens/Registration/index.tsx
@@ -22,6 +22,10 @@ import {
   importProfilesAsCompetitors,
 } from '../../services/firebase/athletes';
 import { tryAutoLinkCompetitor } from '../../services/competitorLinking';
+import {
+  importCompetitorsFromExcel,
+  ImportedCompetitorRow,
+} from '../../utils/importExcel';
 
 const CATEGORIES: { label: string; value: RiderCategory; hint: string }[] = [
   { label: 'Profissional', value: 'Open', hint: 'Grupo 1D' },
@@ -52,6 +56,15 @@ export default function Registration() {
 
   const [deleteTarget, setDeleteTarget] = useState<Competitor | null>(null);
   const [isSorting, setIsSorting] = useState(false);
+
+  // Importação via planilha
+  const [sheetImportOpen, setSheetImportOpen] = useState(false);
+  const [sheetRows, setSheetRows] = useState<ImportedCompetitorRow[]>([]);
+  const [sheetStep, setSheetStep] = useState<'upload' | 'confirm'>('upload');
+  const [importToCompetition, setImportToCompetition] = useState(true);
+  const [importToBase, setImportToBase] = useState(false);
+  const [isImporting, setIsImporting] = useState(false);
+  const sheetInputRef = useRef<HTMLInputElement>(null);
 
   // Base de atletas
   const [athletePickerOpen, setAthletePickerOpen] = useState(false);
@@ -161,6 +174,70 @@ export default function Registration() {
       toast(err.message, 'error');
     } finally {
       setIsSorting(false);
+    }
+  }
+
+  async function handleSheetFile(file: File) {
+    try {
+      const rows = await importCompetitorsFromExcel(file);
+      if (rows.length === 0) {
+        toast('Nenhum competidor encontrado na planilha. Verifique as colunas Nome e Categoria.', 'error');
+        return;
+      }
+      setSheetRows(rows);
+      setSheetStep('confirm');
+    } catch {
+      toast('Erro ao ler a planilha. Verifique o formato do arquivo.', 'error');
+    }
+  }
+
+  async function handleSheetImport() {
+    if (!importToCompetition && !importToBase) {
+      toast('Selecione pelo menos um destino para importar.', 'error');
+      return;
+    }
+    setIsImporting(true);
+    try {
+      const existingNames = new Set(competitors.map((c) => c.name.toLowerCase()));
+      const toAdd = sheetRows.filter((r) => !existingNames.has(r.name.toLowerCase()));
+
+      if (importToCompetition) {
+        const newCompetitors: Competitor[] = toAdd.map((r) => ({
+          id: crypto.randomUUID(),
+          name: r.name,
+          category: r.category,
+          passes: numRounds,
+        }));
+        setCompetitors([...competitors, ...newCompetitors]);
+        if (id) newCompetitors.forEach((c) => tryAutoLinkCompetitor(c, id));
+      }
+
+      if (importToBase && user?.uid) {
+        const toSave = importToCompetition ? toAdd : sheetRows;
+        await Promise.all(
+          toSave.map((r) =>
+            saveAthlete(user.uid!, { name: r.name, category: r.category }).catch(() => null)
+          )
+        );
+      }
+
+      const added = toAdd.length;
+      const skipped = sheetRows.length - toAdd.length;
+      const parts: string[] = [];
+      if (importToCompetition && added > 0) parts.push(`${added} adicionado(s) à competição`);
+      if (skipped > 0) parts.push(`${skipped} ignorado(s) (já cadastrados)`);
+      if (importToBase) parts.push('salvos na base');
+      toast(parts.join(', ') || 'Nenhum competidor novo para importar.', added > 0 ? 'success' : 'info');
+
+      setSheetImportOpen(false);
+      setSheetRows([]);
+      setSheetStep('upload');
+      setImportToCompetition(true);
+      setImportToBase(false);
+    } catch {
+      toast('Erro ao importar competidores.', 'error');
+    } finally {
+      setIsImporting(false);
     }
   }
 
@@ -284,6 +361,15 @@ export default function Registration() {
 
             <Button variant="outline" size="sm" onClick={() => setAthletePickerOpen(true)} fullWidth>
               Importar da Base
+            </Button>
+
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => { setSheetImportOpen(true); setSheetStep('upload'); }}
+              fullWidth
+            >
+              Importar Planilha
             </Button>
 
             <UpgradeModal isOpen={upgradeOpen} onClose={() => setUpgradeOpen(false)} />
@@ -442,6 +528,125 @@ export default function Registration() {
             </Button>
           </div>
         </div>
+      </Modal>
+
+      {/* Modal: Importar Planilha */}
+      <Modal
+        isOpen={sheetImportOpen}
+        onClose={() => {
+          setSheetImportOpen(false);
+          setSheetRows([]);
+          setSheetStep('upload');
+          setImportToCompetition(true);
+          setImportToBase(false);
+        }}
+        title="Importar Competidores via Planilha"
+        size="md"
+      >
+        {sheetStep === 'upload' ? (
+          <div className="flex flex-col gap-4">
+            <p className="text-sm text-rope-600">
+              Selecione uma planilha <span className="font-medium">.xlsx</span> ou <span className="font-medium">.xls</span> com as colunas <span className="font-medium">Nome</span> e <span className="font-medium">Categoria</span>.
+            </p>
+            <div className="rounded-lg border-2 border-dashed border-dust-300 bg-dust-50 p-6 text-center">
+              <p className="text-xs text-rope-400 mb-3">Valores aceitos em Categoria: Profissional, Open, 1D, Amador, AmateurLight, 2D</p>
+              <input
+                ref={sheetInputRef}
+                type="file"
+                accept=".xlsx,.xls,.csv"
+                className="hidden"
+                onChange={(e) => {
+                  const file = e.target.files?.[0];
+                  if (file) handleSheetFile(file);
+                  e.target.value = '';
+                }}
+              />
+              <Button onClick={() => sheetInputRef.current?.click()} variant="outline">
+                Selecionar arquivo
+              </Button>
+            </div>
+            <div className="flex justify-end">
+              <Button
+                variant="ghost"
+                onClick={() => {
+                  setSheetImportOpen(false);
+                  setSheetStep('upload');
+                }}
+              >
+                Cancelar
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-4">
+            <p className="text-sm text-rope-600">
+              <span className="font-semibold text-rope-800">{sheetRows.length}</span> competidor(es) encontrado(s). Escolha onde deseja importar:
+            </p>
+
+            <div className="flex flex-col gap-2 p-3 rounded-lg bg-dust-50 border border-dust-200">
+              <label className="flex items-center gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={importToCompetition}
+                  onChange={(e) => setImportToCompetition(e.target.checked)}
+                  className="w-4 h-4 rounded border-dust-400 text-saddle-600 focus:ring-hay-400"
+                />
+                <div>
+                  <p className="text-sm font-medium text-rope-800">Adicionar à competição atual</p>
+                  <p className="text-xs text-rope-500">Competidores ficam disponíveis nesta competição</p>
+                </div>
+              </label>
+              <label className="flex items-center gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={importToBase}
+                  onChange={(e) => setImportToBase(e.target.checked)}
+                  className="w-4 h-4 rounded border-dust-400 text-saddle-600 focus:ring-hay-400"
+                />
+                <div>
+                  <p className="text-sm font-medium text-rope-800">Salvar na base de atletas</p>
+                  <p className="text-xs text-rope-500">Ficam disponíveis para reutilizar em futuras competições</p>
+                </div>
+              </label>
+            </div>
+
+            <ul className="divide-y divide-dust-200 max-h-56 overflow-y-auto border border-dust-200 rounded-lg">
+              {sheetRows.map((r, i) => (
+                <li key={i} className="flex items-center justify-between px-4 py-2">
+                  <span className="text-sm text-rope-800">{r.name}</span>
+                  <CategoryBadge category={r.category} />
+                </li>
+              ))}
+            </ul>
+
+            <div className="flex justify-between gap-2 pt-1">
+              <Button variant="ghost" size="sm" onClick={() => setSheetStep('upload')}>
+                ← Voltar
+              </Button>
+              <div className="flex gap-2">
+                <Button
+                  variant="ghost"
+                  onClick={() => {
+                    setSheetImportOpen(false);
+                    setSheetRows([]);
+                    setSheetStep('upload');
+                    setImportToCompetition(true);
+                    setImportToBase(false);
+                  }}
+                >
+                  Cancelar
+                </Button>
+                <Button
+                  onClick={handleSheetImport}
+                  loading={isImporting}
+                  disabled={!importToCompetition && !importToBase}
+                >
+                  Importar
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
       </Modal>
 
       <ConfirmModal

--- a/src/utils/importExcel.ts
+++ b/src/utils/importExcel.ts
@@ -1,6 +1,55 @@
 import * as XLSX from 'xlsx';
 import { Duo } from 'core/models/Duo';
-import { Competitor } from 'core/index';
+import { Competitor, RiderCategory, normalizeCategory } from 'core/index';
+
+export interface ImportedCompetitorRow {
+  name: string;
+  category: RiderCategory;
+}
+
+function parseCategoryValue(raw: string): RiderCategory {
+  const v = (raw ?? '').toLowerCase().trim().replace(/\s+/g, '');
+  if (
+    v === 'amador' || v === 'amateurlight' || v === 'amadorlight' ||
+    v === 'beginner' || v === '2d' || v === 'amador/light'
+  ) {
+    return 'AmateurLight';
+  }
+  return normalizeCategory(raw) ?? 'Open';
+}
+
+export function importCompetitorsFromExcel(file: File): Promise<ImportedCompetitorRow[]> {
+  return new Promise(async (resolve, reject) => {
+    try {
+      const data = await file.arrayBuffer();
+      const workbook = XLSX.read(data, { type: 'array' });
+      const sheet = workbook.Sheets[workbook.SheetNames[0]];
+      const rows: any[] = XLSX.utils.sheet_to_json(sheet);
+
+      const parsed: ImportedCompetitorRow[] = [];
+      for (const row of rows) {
+        // Accept column names in pt-BR or English, case-insensitive
+        const keys = Object.keys(row).reduce<Record<string, string>>((acc, k) => {
+          acc[k.toLowerCase().trim()] = k;
+          return acc;
+        }, {});
+
+        const nameKey = keys['nome'] ?? keys['name'] ?? keys['competidor'] ?? keys['atleta'];
+        const catKey = keys['categoria'] ?? keys['category'] ?? keys['cat'];
+
+        const name = nameKey ? String(row[nameKey] ?? '').trim() : '';
+        const catRaw = catKey ? String(row[catKey] ?? '') : '';
+
+        if (!name) continue;
+        parsed.push({ name, category: parseCategoryValue(catRaw) });
+      }
+
+      resolve(parsed);
+    } catch (err) {
+      reject(err);
+    }
+  });
+}
 
 export async function importDuosFromExcel(
   file: File,


### PR DESCRIPTION
Adiciona botão "Importar Planilha" na tela de inscrições que:
- Lê .xlsx/.xls com colunas Nome e Categoria (pt-BR e en aceitos)
- Normaliza categorias (Amador/2D → AmateurLight, Profissional/1D/Open → Open)
- Pergunta ao organizador se deve adicionar à competição, à base de atletas ou ambos
- Mostra preview dos competidores antes de confirmar
- Ignora duplicatas por nome (case-insensitive)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CbJpshCaHWpfTVi6JKYhM9